### PR TITLE
Add conversion context

### DIFF
--- a/src/main/java/info/kfgodel/bean2bean/core/api/Bean2bean.java
+++ b/src/main/java/info/kfgodel/bean2bean/core/api/Bean2bean.java
@@ -1,7 +1,6 @@
 package info.kfgodel.bean2bean.core.api;
 
 import info.kfgodel.bean2bean.core.api.registry.Bean2BeanRegistry;
-import info.kfgodel.bean2bean.core.impl.conversion.ObjectConversion;
 
 /**
  * This type represents the interface for the core bean2bean functionality.<br>
@@ -18,7 +17,7 @@ public interface Bean2bean {
    * @param <O> The expected result type
    * @return The result of processing the task
    */
-  <O> O process(ObjectConversion task);
+  <O> O process(Bean2beanTask task);
 
   /**
    * Allows access to the converter registry for this instance.<br>

--- a/src/main/java/info/kfgodel/bean2bean/core/api/Bean2beanTask.java
+++ b/src/main/java/info/kfgodel/bean2bean/core/api/Bean2beanTask.java
@@ -1,6 +1,7 @@
 package info.kfgodel.bean2bean.core.api;
 
 import info.kfgodel.bean2bean.core.api.registry.DomainVector;
+import info.kfgodel.bean2bean.dsl.api.B2bDsl;
 
 /**
  * This type represents a task that can be processed by a {@link Bean2bean} core
@@ -18,4 +19,10 @@ public interface Bean2beanTask {
    * @return The input for the conversion
    */
   Object getSource();
+
+  /**
+   * Returns the dsl instance that is contextual to this task and can be used for nesting tasks
+   * @return The dsl to ease task definitions
+   */
+  B2bDsl getDsl();
 }

--- a/src/main/java/info/kfgodel/bean2bean/core/api/Bean2beanTask.java
+++ b/src/main/java/info/kfgodel/bean2bean/core/api/Bean2beanTask.java
@@ -1,8 +1,21 @@
 package info.kfgodel.bean2bean.core.api;
 
+import info.kfgodel.bean2bean.core.api.registry.DomainVector;
+
 /**
- * This type represents the super type of all possible bean2bean tasks
+ * This type represents a task that can be processed by a {@link Bean2bean} core
  * Date: 12/02/19 - 00:08
  */
 public interface Bean2beanTask {
+  /**
+   * The vector that indicates from which domain to which codomain this task generates a result
+   * @return A domain vector indicating the direction for a conversion
+   */
+  DomainVector getConversionVector();
+
+  /**
+   * The object that is the source of the conversion from which a result must be generated
+   * @return The input for the conversion
+   */
+  Object getSource();
 }

--- a/src/main/java/info/kfgodel/bean2bean/core/api/exceptions/ConversionException.java
+++ b/src/main/java/info/kfgodel/bean2bean/core/api/exceptions/ConversionException.java
@@ -1,6 +1,6 @@
 package info.kfgodel.bean2bean.core.api.exceptions;
 
-import info.kfgodel.bean2bean.core.api.registry.DomainVector;
+import info.kfgodel.bean2bean.core.api.Bean2beanTask;
 
 /**
  * This type represents an error during a conversion attempt
@@ -8,20 +8,14 @@ import info.kfgodel.bean2bean.core.api.registry.DomainVector;
  */
 public class ConversionException extends Bean2BeanException {
 
-  private final Object source;
-  private final DomainVector conversionVector;
+  private final Bean2beanTask task;
 
-  public ConversionException(String message, Object source, DomainVector conversionVector) {
+  public ConversionException(String message, Bean2beanTask task) {
     super(message);
-    this.conversionVector = conversionVector;
-    this.source = source;
+    this.task = task;
   }
 
-  public Object getSource() {
-    return source;
-  }
-
-  public DomainVector getConversionVector() {
-    return conversionVector;
+  public Bean2beanTask getTask() {
+    return task;
   }
 }

--- a/src/main/java/info/kfgodel/bean2bean/core/api/registry/Bean2BeanRegistry.java
+++ b/src/main/java/info/kfgodel/bean2bean/core/api/registry/Bean2BeanRegistry.java
@@ -1,9 +1,9 @@
 package info.kfgodel.bean2bean.core.api.registry;
 
+import info.kfgodel.bean2bean.core.api.Bean2beanTask;
 import info.kfgodel.bean2bean.core.api.registry.definitions.ConverterDefinition;
 import info.kfgodel.bean2bean.core.api.registry.definitions.PredicateScopedDefinition;
 import info.kfgodel.bean2bean.core.api.registry.definitions.VectorScopedDefinition;
-import info.kfgodel.bean2bean.core.impl.conversion.ObjectConversion;
 
 import java.util.Optional;
 import java.util.function.Function;
@@ -22,7 +22,7 @@ public interface Bean2BeanRegistry {
    * @param <O> The type of expected output
    * @return The process found, or empty if none exists for the input
    */
-  <O> Optional<Function<ObjectConversion,O>> findBestConverterFor(DomainVector conversionVector);
+  <O> Optional<Function<Bean2beanTask,O>> findBestConverterFor(DomainVector conversionVector);
 
 
   /**

--- a/src/main/java/info/kfgodel/bean2bean/core/api/registry/definitions/ConverterDefinition.java
+++ b/src/main/java/info/kfgodel/bean2bean/core/api/registry/definitions/ConverterDefinition.java
@@ -1,6 +1,6 @@
 package info.kfgodel.bean2bean.core.api.registry.definitions;
 
-import info.kfgodel.bean2bean.core.impl.conversion.ObjectConversion;
+import info.kfgodel.bean2bean.core.api.Bean2beanTask;
 
 import java.util.function.Function;
 
@@ -14,5 +14,5 @@ public interface ConverterDefinition {
   /**
    * @return The function that can be used as converter to transform input into output
    */
-  <O> Function<ObjectConversion, O> getConverter();
+  <O> Function<Bean2beanTask, O> getConverter();
 }

--- a/src/main/java/info/kfgodel/bean2bean/core/impl/conversion/BiFunctionAdapterConverter.java
+++ b/src/main/java/info/kfgodel/bean2bean/core/impl/conversion/BiFunctionAdapterConverter.java
@@ -1,7 +1,6 @@
 package info.kfgodel.bean2bean.core.impl.conversion;
 
 import info.kfgodel.bean2bean.core.api.Bean2beanTask;
-import info.kfgodel.bean2bean.dsl.api.B2bDsl;
 
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -14,20 +13,18 @@ import java.util.function.Function;
  */
 public class BiFunctionAdapterConverter implements Function<Bean2beanTask, Object> {
 
-  private B2bDsl b2bDsl;
-  private BiFunction biFunction;
+  private BiFunction<Object,Bean2beanTask,Object> biFunction;
 
   @Override
-  public Object apply(Bean2beanTask objectConversion) {
-    Object input = objectConversion.getSource();
-    Object output = biFunction.apply(input, b2bDsl);
+  public Object apply(Bean2beanTask task) {
+    Object input = task.getSource();
+    Object output = biFunction.apply(input, task);
     return output;
   }
 
-  public static BiFunctionAdapterConverter create(BiFunction function, B2bDsl b2bDsl) {
+  public static BiFunctionAdapterConverter create(BiFunction<?, Bean2beanTask, ?> function) {
     BiFunctionAdapterConverter converter = new BiFunctionAdapterConverter();
-    converter.biFunction = function;
-    converter.b2bDsl = b2bDsl;
+    converter.biFunction = (BiFunction<Object, Bean2beanTask, Object>) function;
     return converter;
   }
 

--- a/src/main/java/info/kfgodel/bean2bean/core/impl/conversion/BiFunctionAdapterConverter.java
+++ b/src/main/java/info/kfgodel/bean2bean/core/impl/conversion/BiFunctionAdapterConverter.java
@@ -1,5 +1,6 @@
 package info.kfgodel.bean2bean.core.impl.conversion;
 
+import info.kfgodel.bean2bean.core.api.Bean2beanTask;
 import info.kfgodel.bean2bean.dsl.api.B2bDsl;
 
 import java.util.function.BiFunction;
@@ -11,13 +12,13 @@ import java.util.function.Function;
  *
  * Date: 16/02/19 - 14:30
  */
-public class BiFunctionAdapterConverter implements Function<ObjectConversion, Object> {
+public class BiFunctionAdapterConverter implements Function<Bean2beanTask, Object> {
 
   private B2bDsl b2bDsl;
   private BiFunction biFunction;
 
   @Override
-  public Object apply(ObjectConversion objectConversion) {
+  public Object apply(Bean2beanTask objectConversion) {
     Object input = objectConversion.getSource();
     Object output = biFunction.apply(input, b2bDsl);
     return output;

--- a/src/main/java/info/kfgodel/bean2bean/core/impl/conversion/ConsumerAdapterConverter.java
+++ b/src/main/java/info/kfgodel/bean2bean/core/impl/conversion/ConsumerAdapterConverter.java
@@ -1,5 +1,7 @@
 package info.kfgodel.bean2bean.core.impl.conversion;
 
+import info.kfgodel.bean2bean.core.api.Bean2beanTask;
+
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -7,12 +9,12 @@ import java.util.function.Function;
  * This type adapts a consumer function into a converter function
  * Date: 17/02/19 - 13:06
  */
-public class ConsumerAdapterConverter implements Function<ObjectConversion, Object> {
+public class ConsumerAdapterConverter implements Function<Bean2beanTask, Object> {
 
   private Consumer consumer;
 
   @Override
-  public Object apply(ObjectConversion objectConversion) {
+  public Object apply(Bean2beanTask objectConversion) {
     Object input = objectConversion.getSource();
     consumer.accept(input);
     return null;

--- a/src/main/java/info/kfgodel/bean2bean/core/impl/conversion/ConsumerAdapterConverter.java
+++ b/src/main/java/info/kfgodel/bean2bean/core/impl/conversion/ConsumerAdapterConverter.java
@@ -11,7 +11,7 @@ import java.util.function.Function;
  */
 public class ConsumerAdapterConverter implements Function<Bean2beanTask, Object> {
 
-  private Consumer consumer;
+  private Consumer<Object> consumer;
 
   @Override
   public Object apply(Bean2beanTask objectConversion) {
@@ -22,7 +22,7 @@ public class ConsumerAdapterConverter implements Function<Bean2beanTask, Object>
 
   public static ConsumerAdapterConverter create(Consumer<?> consumer) {
     ConsumerAdapterConverter converter = new ConsumerAdapterConverter();
-    converter.consumer = consumer;
+    converter.consumer = (Consumer<Object>) consumer;
     return converter;
   }
 

--- a/src/main/java/info/kfgodel/bean2bean/core/impl/conversion/FunctionAdapterConverter.java
+++ b/src/main/java/info/kfgodel/bean2bean/core/impl/conversion/FunctionAdapterConverter.java
@@ -1,17 +1,19 @@
 package info.kfgodel.bean2bean.core.impl.conversion;
 
+import info.kfgodel.bean2bean.core.api.Bean2beanTask;
+
 import java.util.function.Function;
 
 /**
  * This type represents the converter based on a simple function to do the actual conversion from input value
  * Date: 12/02/19 - 01:18
  */
-public class FunctionAdapterConverter implements Function<ObjectConversion, Object> {
+public class FunctionAdapterConverter implements Function<Bean2beanTask, Object> {
 
   private Function function;
 
   @Override
-  public Object apply(ObjectConversion objectConversion) {
+  public Object apply(Bean2beanTask objectConversion) {
     Object input = objectConversion.getSource();
     Object output = function.apply(input);
     return output;

--- a/src/main/java/info/kfgodel/bean2bean/core/impl/conversion/FunctionAdapterConverter.java
+++ b/src/main/java/info/kfgodel/bean2bean/core/impl/conversion/FunctionAdapterConverter.java
@@ -10,7 +10,7 @@ import java.util.function.Function;
  */
 public class FunctionAdapterConverter implements Function<Bean2beanTask, Object> {
 
-  private Function function;
+  private Function<Object, Object> function;
 
   @Override
   public Object apply(Bean2beanTask objectConversion) {
@@ -19,9 +19,9 @@ public class FunctionAdapterConverter implements Function<Bean2beanTask, Object>
     return output;
   }
 
-  public static FunctionAdapterConverter create(Function function) {
+  public static FunctionAdapterConverter create(Function<?,?> function) {
     FunctionAdapterConverter process = new FunctionAdapterConverter();
-    process.function = function;
+    process.function = (Function<Object, Object>) function;
     return process;
   }
 

--- a/src/main/java/info/kfgodel/bean2bean/core/impl/conversion/ObjectConversion.java
+++ b/src/main/java/info/kfgodel/bean2bean/core/impl/conversion/ObjectConversion.java
@@ -2,6 +2,7 @@ package info.kfgodel.bean2bean.core.impl.conversion;
 
 import info.kfgodel.bean2bean.core.api.Bean2beanTask;
 import info.kfgodel.bean2bean.core.api.registry.DomainVector;
+import info.kfgodel.bean2bean.dsl.api.B2bDsl;
 
 /**
  * This class represents the task that {@link info.kfgodel.bean2bean.core.api.Bean2bean} can process
@@ -13,11 +14,13 @@ public class ObjectConversion implements Bean2beanTask {
 
   private Object source;
   private DomainVector conversionVector;
+  private B2bDsl dsl;
 
-  public static ObjectConversion create(Object source, DomainVector conversionVector) {
+  public static ObjectConversion create(Object source, DomainVector conversionVector, B2bDsl dsl) {
     ObjectConversion conversion = new ObjectConversion();
     conversion.source = source;
     conversion.conversionVector = conversionVector;
+    conversion.dsl = dsl;
     return conversion;
   }
 
@@ -29,5 +32,10 @@ public class ObjectConversion implements Bean2beanTask {
   @Override
   public Object getSource() {
     return source;
+  }
+
+  @Override
+  public B2bDsl getDsl() {
+    return dsl;
   }
 }

--- a/src/main/java/info/kfgodel/bean2bean/core/impl/conversion/ObjectConversion.java
+++ b/src/main/java/info/kfgodel/bean2bean/core/impl/conversion/ObjectConversion.java
@@ -1,11 +1,12 @@
 package info.kfgodel.bean2bean.core.impl.conversion;
 
 import info.kfgodel.bean2bean.core.api.Bean2beanTask;
-import info.kfgodel.bean2bean.core.api.exceptions.ConversionException;
 import info.kfgodel.bean2bean.core.api.registry.DomainVector;
 
 /**
- * This class represents the definition of an expected conversion
+ * This class represents the task that {@link info.kfgodel.bean2bean.core.api.Bean2bean} can process
+ * to convert an object from one domain to another domain (possibly generating a new object)
+ * 
  * Date: 12/02/19 - 00:06
  */
 public class ObjectConversion implements Bean2beanTask {
@@ -20,14 +21,12 @@ public class ObjectConversion implements Bean2beanTask {
     return conversion;
   }
 
+  @Override
   public DomainVector getConversionVector(){
     return conversionVector;
   }
 
-  public ConversionException exceptionForMissingConverter() {
-    return new ConversionException("No converter found from " + source + getConversionVector().getSource() + " to " + getConversionVector().getTarget(), source, conversionVector);
-  }
-
+  @Override
   public Object getSource() {
     return source;
   }

--- a/src/main/java/info/kfgodel/bean2bean/core/impl/conversion/SupplierAdapterConverter.java
+++ b/src/main/java/info/kfgodel/bean2bean/core/impl/conversion/SupplierAdapterConverter.java
@@ -11,16 +11,16 @@ import java.util.function.Supplier;
  */
 public class SupplierAdapterConverter implements Function<Bean2beanTask, Object> {
 
-  private Supplier function;
+  private Supplier<Object> function;
 
   @Override
   public Object apply(Bean2beanTask objectConversion) {
     return function.get();
   }
 
-  public static SupplierAdapterConverter create(Supplier function) {
+  public static SupplierAdapterConverter create(Supplier<?> function) {
     SupplierAdapterConverter converter = new SupplierAdapterConverter();
-    converter.function = function;
+    converter.function = (Supplier<Object>) function;
     return converter;
   }
 

--- a/src/main/java/info/kfgodel/bean2bean/core/impl/conversion/SupplierAdapterConverter.java
+++ b/src/main/java/info/kfgodel/bean2bean/core/impl/conversion/SupplierAdapterConverter.java
@@ -1,5 +1,7 @@
 package info.kfgodel.bean2bean.core.impl.conversion;
 
+import info.kfgodel.bean2bean.core.api.Bean2beanTask;
+
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -7,12 +9,12 @@ import java.util.function.Supplier;
  * This class serves as an adapter between a supplier function and the converter interface
  * Date: 16/02/19 - 18:33
  */
-public class SupplierAdapterConverter implements Function<ObjectConversion, Object> {
+public class SupplierAdapterConverter implements Function<Bean2beanTask, Object> {
 
   private Supplier function;
 
   @Override
-  public Object apply(ObjectConversion objectConversion) {
+  public Object apply(Bean2beanTask objectConversion) {
     return function.get();
   }
 

--- a/src/main/java/info/kfgodel/bean2bean/core/impl/registry/DefaultRegistry.java
+++ b/src/main/java/info/kfgodel/bean2bean/core/impl/registry/DefaultRegistry.java
@@ -1,12 +1,12 @@
 package info.kfgodel.bean2bean.core.impl.registry;
 
+import info.kfgodel.bean2bean.core.api.Bean2beanTask;
 import info.kfgodel.bean2bean.core.api.registry.Bean2BeanRegistry;
 import info.kfgodel.bean2bean.core.api.registry.Domain;
 import info.kfgodel.bean2bean.core.api.registry.DomainVector;
 import info.kfgodel.bean2bean.core.api.registry.definitions.ConverterDefinition;
 import info.kfgodel.bean2bean.core.api.registry.definitions.PredicateScopedDefinition;
 import info.kfgodel.bean2bean.core.api.registry.definitions.VectorScopedDefinition;
-import info.kfgodel.bean2bean.core.impl.conversion.ObjectConversion;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -35,7 +35,7 @@ public class DefaultRegistry implements Bean2BeanRegistry {
   }
 
   @Override
-  public <O> Optional<Function<ObjectConversion, O>> findBestConverterFor(DomainVector vector) {
+  public <O> Optional<Function<Bean2beanTask, O>> findBestConverterFor(DomainVector vector) {
     return this.cache.retrieveCachedOrProduceFor(vector, this::calculateBestConverterFor);
   }
 
@@ -49,7 +49,7 @@ public class DefaultRegistry implements Bean2BeanRegistry {
     throw new IllegalArgumentException("The given definition["+definition+"] is not supported on this registry");
   }
 
-  private <O> Optional<Function<ObjectConversion, O>> calculateBestConverterFor(DomainVector vector) {
+  private <O> Optional<Function<Bean2beanTask, O>> calculateBestConverterFor(DomainVector vector) {
     Optional<ConverterDefinition> foundDefinition = this.lookForVectorBasedMatchingHiearchiesOf(vector);
     if(!foundDefinition.isPresent()){
       // I can't find a better way to express this with native optionals

--- a/src/main/java/info/kfgodel/bean2bean/core/impl/registry/definitions/PredicateDefinition.java
+++ b/src/main/java/info/kfgodel/bean2bean/core/impl/registry/definitions/PredicateDefinition.java
@@ -1,8 +1,8 @@
 package info.kfgodel.bean2bean.core.impl.registry.definitions;
 
+import info.kfgodel.bean2bean.core.api.Bean2beanTask;
 import info.kfgodel.bean2bean.core.api.registry.DomainVector;
 import info.kfgodel.bean2bean.core.api.registry.definitions.PredicateScopedDefinition;
-import info.kfgodel.bean2bean.core.impl.conversion.ObjectConversion;
 
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -14,7 +14,7 @@ import java.util.function.Predicate;
 public class PredicateDefinition implements PredicateScopedDefinition {
 
   private Predicate<DomainVector> predicate;
-  private Function<ObjectConversion, Object> converter;
+  private Function<Bean2beanTask, Object> converter;
 
   @Override
   public Predicate<DomainVector> getScopePredicate() {
@@ -22,11 +22,11 @@ public class PredicateDefinition implements PredicateScopedDefinition {
   }
 
   @Override
-  public Function<ObjectConversion, Object> getConverter() {
+  public Function<Bean2beanTask, Object> getConverter() {
     return converter;
   }
 
-  public static PredicateDefinition create(Function<ObjectConversion, Object> converter, Predicate<DomainVector> predicate) {
+  public static PredicateDefinition create(Function<Bean2beanTask, Object> converter, Predicate<DomainVector> predicate) {
     PredicateDefinition definition = new PredicateDefinition();
     definition.predicate = predicate;
     definition.converter = converter;

--- a/src/main/java/info/kfgodel/bean2bean/core/impl/registry/definitions/VectorDefinition.java
+++ b/src/main/java/info/kfgodel/bean2bean/core/impl/registry/definitions/VectorDefinition.java
@@ -1,8 +1,8 @@
 package info.kfgodel.bean2bean.core.impl.registry.definitions;
 
+import info.kfgodel.bean2bean.core.api.Bean2beanTask;
 import info.kfgodel.bean2bean.core.api.registry.DomainVector;
 import info.kfgodel.bean2bean.core.api.registry.definitions.VectorScopedDefinition;
-import info.kfgodel.bean2bean.core.impl.conversion.ObjectConversion;
 
 import java.util.function.Function;
 
@@ -13,7 +13,7 @@ import java.util.function.Function;
 public class VectorDefinition implements VectorScopedDefinition {
 
   private DomainVector conversionVector;
-  private Function<ObjectConversion, Object> converter;
+  private Function<Bean2beanTask, Object> converter;
 
   @Override
   public DomainVector getConversionVector() {
@@ -21,11 +21,11 @@ public class VectorDefinition implements VectorScopedDefinition {
   }
 
   @Override
-  public Function<ObjectConversion, Object> getConverter() {
+  public Function<Bean2beanTask, Object> getConverter() {
     return converter;
   }
 
-  public static VectorDefinition create(Function<ObjectConversion, Object> converter, DomainVector conversionVector) {
+  public static VectorDefinition create(Function<Bean2beanTask, Object> converter, DomainVector conversionVector) {
     VectorDefinition definition = new VectorDefinition();
     definition.converter = converter;
     definition.conversionVector = conversionVector;

--- a/src/main/java/info/kfgodel/bean2bean/core/impl/registry/domains/DomainVectorExtractor.java
+++ b/src/main/java/info/kfgodel/bean2bean/core/impl/registry/domains/DomainVectorExtractor.java
@@ -2,7 +2,6 @@ package info.kfgodel.bean2bean.core.impl.registry.domains;
 
 import info.kfgodel.bean2bean.core.api.registry.Domain;
 import info.kfgodel.bean2bean.core.api.registry.DomainVector;
-import info.kfgodel.bean2bean.dsl.api.B2bDsl;
 import info.kfgodel.bean2bean.other.references.BiFunctionRef;
 import info.kfgodel.bean2bean.other.references.ConsumerRef;
 import info.kfgodel.bean2bean.other.references.FunctionRef;
@@ -64,7 +63,7 @@ public class DomainVectorExtractor {
     return createVectorFor(inputType, outputType);
   }
 
-  public DomainVector extractFrom(BiFunction<?, B2bDsl, ?> biFunction) {
+  public DomainVector extractFrom(BiFunction<?, ?, ?> biFunction) {
     List<Type> arguments = typeExtractor.getArgumentsUsedFor(BiFunction.class, biFunction.getClass())
       .collect(Collectors.toList());
     Type inputType = arguments.isEmpty() ? Object.class : arguments.get(0);
@@ -72,7 +71,7 @@ public class DomainVectorExtractor {
     return createVectorFor(inputType, outputType);
   }
 
-  public DomainVector extractFrom(BiFunctionRef<?, B2bDsl, ?> converterFunction) {
+  public DomainVector extractFrom(BiFunctionRef<?, ?, ?> converterFunction) {
     Type outputType = converterFunction.getOutputType();
     Type firstInputType = converterFunction.getFirstInputType();
     return createVectorFor(firstInputType, outputType);

--- a/src/main/java/info/kfgodel/bean2bean/dsl/api/ConfigureDsl.java
+++ b/src/main/java/info/kfgodel/bean2bean/dsl/api/ConfigureDsl.java
@@ -1,5 +1,6 @@
 package info.kfgodel.bean2bean.dsl.api;
 
+import info.kfgodel.bean2bean.core.api.Bean2beanTask;
 import info.kfgodel.bean2bean.core.api.registry.DomainVector;
 import info.kfgodel.bean2bean.other.references.BiFunctionRef;
 import info.kfgodel.bean2bean.other.references.ConsumerRef;
@@ -49,31 +50,31 @@ public interface ConfigureDsl {
   <I,O> ConfigureDsl usingConverter(FunctionRef<I,O> converterFunctionRef);
 
   /**
-   * Registers a converter that will need access to b2b dsl as part of the conversion process. Usually
-   * for delegating the conversion of one or mor parts of the original object.
+   * Registers a converter that will need access to the task as part of the conversion process. Usually
+   * for delegating the conversion of one or more parts of the original object (nesting conversions).
    * @param converterFunction The function to use as converter
    * @return This instance for method chaining
    */
-  <I,O> ConfigureDsl usingConverter(BiFunction<I,B2bDsl,O> converterFunction);
+  <I,O> ConfigureDsl usingConverter(BiFunction<I, Bean2beanTask,O> converterFunction);
 
   /**
-   * Registers a converter that will need access to b2b dsl as part of the conversion process. Usually
-   * for delegating the conversion of one or mor parts of the original object.<br>
+   * Registers a converter that will need access to the task as part of the conversion process. Usually
+   * for delegating the conversion of one or more parts of the original object (nesting conversions).<br>
    * The predicate is evaluated on the conversion domain vector to decide if the converter can be used,
    *   but only if no other type scoped converter matches first.<br>
    * @param converterFunction The function to use as converter
    * @param scopePredicate The predicate that returns true on a domain vector when the converter can be used
    * @return This instance for method chaining
    */
-  ConfigureDsl usingConverter(BiFunction<?,B2bDsl,?> converterFunction, Predicate<DomainVector> scopePredicate);
+  ConfigureDsl usingConverter(BiFunction<?,Bean2beanTask,?> converterFunction, Predicate<DomainVector> scopePredicate);
 
   /**
    * Registers a converter function though its reference that will need access to b2b dsl as part of
-   * the conversion process. Usually for delegating the conversion of one or mor parts of the original object.
+   * the conversion process. Usually for delegating the conversion of one or more parts of the original object (nesting conversions).
    * @param converterFunction The function to use as converter
    * @return This instance for method chaining
    */
-  <I,O> ConfigureDsl usingConverter(BiFunctionRef<I,B2bDsl,O> converterFunction);
+  <I,O> ConfigureDsl usingConverter(BiFunctionRef<I,Bean2beanTask,O> converterFunction);
 
   /**
    * Registers a converter function that requires no parameters as input for the conversion.<br>

--- a/src/main/java/info/kfgodel/bean2bean/dsl/impl/ConfigureDslImpl.java
+++ b/src/main/java/info/kfgodel/bean2bean/dsl/impl/ConfigureDslImpl.java
@@ -59,19 +59,19 @@ public class ConfigureDslImpl implements ConfigureDsl {
   }
 
   @Override
-  public <I,O> ConfigureDsl usingConverter(BiFunction<I, B2bDsl, O> converterFunction) {
+  public <I,O> ConfigureDsl usingConverter(BiFunction<I, Bean2beanTask, O> converterFunction) {
     DomainVector implicitVector = vectorExtractor.extractFrom(converterFunction);
     return usingConverter(implicitVector, converterFunction);
   }
 
   @Override
-  public ConfigureDsl usingConverter(BiFunction<?, B2bDsl, ?> converterFunction, Predicate<DomainVector> scopePredicate) {
-    BiFunctionAdapterConverter converter = BiFunctionAdapterConverter.create(converterFunction, this.b2bDsl);
+  public ConfigureDsl usingConverter(BiFunction<?, Bean2beanTask, ?> converterFunction, Predicate<DomainVector> scopePredicate) {
+    BiFunctionAdapterConverter converter = BiFunctionAdapterConverter.create(converterFunction);
     return usingConverterFor(converter, scopePredicate);
   }
 
   @Override
-  public <I,O> ConfigureDsl usingConverter(BiFunctionRef<I, B2bDsl, O> converterFunction) {
+  public <I,O> ConfigureDsl usingConverter(BiFunctionRef<I, Bean2beanTask, O> converterFunction) {
     DomainVector implicitVector = vectorExtractor.extractFrom(converterFunction);
     return usingConverter(implicitVector, converterFunction.getBiFunction());
   }
@@ -128,7 +128,7 @@ public class ConfigureDslImpl implements ConfigureDsl {
     return usingConverterFor(conversionVector, converter);
   }
   private ConfigureDsl usingConverter(DomainVector conversionVector, BiFunction converterFunction) {
-    BiFunctionAdapterConverter converter = BiFunctionAdapterConverter.create(converterFunction, b2bDsl);
+    BiFunctionAdapterConverter converter = BiFunctionAdapterConverter.create(converterFunction);
     return usingConverterFor(conversionVector, converter);
   }
 

--- a/src/main/java/info/kfgodel/bean2bean/dsl/impl/ConfigureDslImpl.java
+++ b/src/main/java/info/kfgodel/bean2bean/dsl/impl/ConfigureDslImpl.java
@@ -1,11 +1,11 @@
 package info.kfgodel.bean2bean.dsl.impl;
 
+import info.kfgodel.bean2bean.core.api.Bean2beanTask;
 import info.kfgodel.bean2bean.core.api.registry.DomainVector;
 import info.kfgodel.bean2bean.core.api.registry.definitions.ConverterDefinition;
 import info.kfgodel.bean2bean.core.impl.conversion.BiFunctionAdapterConverter;
 import info.kfgodel.bean2bean.core.impl.conversion.ConsumerAdapterConverter;
 import info.kfgodel.bean2bean.core.impl.conversion.FunctionAdapterConverter;
-import info.kfgodel.bean2bean.core.impl.conversion.ObjectConversion;
 import info.kfgodel.bean2bean.core.impl.conversion.SupplierAdapterConverter;
 import info.kfgodel.bean2bean.core.impl.registry.definitions.PredicateDefinition;
 import info.kfgodel.bean2bean.core.impl.registry.definitions.VectorDefinition;
@@ -132,12 +132,12 @@ public class ConfigureDslImpl implements ConfigureDsl {
     return usingConverterFor(conversionVector, converter);
   }
 
-  private ConfigureDsl usingConverterFor(DomainVector conversionVector, Function<ObjectConversion, Object> converter) {
+  private ConfigureDsl usingConverterFor(DomainVector conversionVector, Function<Bean2beanTask, Object> converter) {
     VectorDefinition definition = VectorDefinition.create(converter, conversionVector);
     return usingConverter(definition);
   }
 
-  private ConfigureDsl usingConverterFor(Function<ObjectConversion, Object> converter, Predicate<DomainVector> scopePredicate) {
+  private ConfigureDsl usingConverterFor(Function<Bean2beanTask, Object> converter, Predicate<DomainVector> scopePredicate) {
     PredicateDefinition definition = PredicateDefinition.create(converter, scopePredicate);
     return usingConverter(definition);
   }

--- a/src/main/java/info/kfgodel/bean2bean/dsl/impl/ConvertDslImpl.java
+++ b/src/main/java/info/kfgodel/bean2bean/dsl/impl/ConvertDslImpl.java
@@ -34,4 +34,8 @@ public class ConvertDslImpl implements ConvertDsl {
   public DomainCalculator getCalculator() {
     return parentDsl.getCalculator();
   }
+
+  public B2bDsl getDsl() {
+    return parentDsl;
+  }
 }

--- a/src/main/java/info/kfgodel/bean2bean/dsl/impl/SourceDefinedConversionDslImpl.java
+++ b/src/main/java/info/kfgodel/bean2bean/dsl/impl/SourceDefinedConversionDslImpl.java
@@ -6,6 +6,7 @@ import info.kfgodel.bean2bean.core.api.registry.Domain;
 import info.kfgodel.bean2bean.core.api.registry.DomainVector;
 import info.kfgodel.bean2bean.core.impl.conversion.ObjectConversion;
 import info.kfgodel.bean2bean.core.impl.registry.domains.DomainCalculator;
+import info.kfgodel.bean2bean.dsl.api.B2bDsl;
 import info.kfgodel.bean2bean.dsl.api.SourceDefinedConversionDsl;
 import info.kfgodel.bean2bean.other.references.TypeRef;
 
@@ -49,7 +50,11 @@ public class SourceDefinedConversionDslImpl<I> implements SourceDefinedConversio
 
   private ObjectConversion createConversionTo(Domain targetDomain) {
     DomainVector conversionVector = DomainVector.create(sourceDomain, targetDomain);
-    return ObjectConversion.create(this.value, conversionVector);
+    return ObjectConversion.create(this.value, conversionVector, getDsl());
+  }
+
+  private B2bDsl getDsl() {
+    return parentDsl.getDsl();
   }
 
   private <O> O processConversion(ObjectConversion conversion) {

--- a/src/test/java/info/kfgodel/bean2bean/core/impl/registry/DefaultRegistryTest.java
+++ b/src/test/java/info/kfgodel/bean2bean/core/impl/registry/DefaultRegistryTest.java
@@ -2,9 +2,9 @@ package info.kfgodel.bean2bean.core.impl.registry;
 
 import ar.com.dgarcia.javaspec.api.JavaSpec;
 import ar.com.dgarcia.javaspec.api.JavaSpecRunner;
+import info.kfgodel.bean2bean.core.api.Bean2beanTask;
 import info.kfgodel.bean2bean.core.api.registry.Domain;
 import info.kfgodel.bean2bean.core.api.registry.DomainVector;
-import info.kfgodel.bean2bean.core.impl.conversion.ObjectConversion;
 import info.kfgodel.bean2bean.core.impl.registry.definitions.PredicateDefinition;
 import info.kfgodel.bean2bean.core.impl.registry.definitions.VectorDefinition;
 import info.kfgodel.bean2bean.core.impl.registry.domains.DomainCalculator;
@@ -31,7 +31,7 @@ public class DefaultRegistryTest extends JavaSpec<B2bTestContext> {
 
       describe("when created", () -> {
         it("has no registered converter", () -> {
-          Optional<Function<ObjectConversion, Object>> found = test().registry().findBestConverterFor(listOfIntegersToListOfStrings());
+          Optional<Function<Bean2beanTask, Object>> found = test().registry().findBestConverterFor(listOfIntegersToListOfStrings());
           assertThat(found).isEmpty();
         });
       });
@@ -42,13 +42,13 @@ public class DefaultRegistryTest extends JavaSpec<B2bTestContext> {
         });
 
         it("finds that converter", () -> {
-          Optional<Function<ObjectConversion, Object>> found = test().registry().findBestConverterFor(listOfIntegersToListOfStrings());
+          Optional<Function<Bean2beanTask, Object>> found = test().registry().findBestConverterFor(listOfIntegersToListOfStrings());
           Object converterResult = found.get().apply(null);
           assertThat(converterResult).isEqualTo("List<Integer> -> List<String>");
         });
 
         it("finds no converter if a more generic domain conversion is attempted",()->{
-          Optional<Function<ObjectConversion, Object>> found = test().registry().findBestConverterFor(listToList());
+          Optional<Function<Bean2beanTask, Object>> found = test().registry().findBestConverterFor(listToList());
           assertThat(found).isEmpty();
         });
 
@@ -58,7 +58,7 @@ public class DefaultRegistryTest extends JavaSpec<B2bTestContext> {
           });
 
           it("finds the exact converter",()->{
-            Optional<Function<ObjectConversion, Object>> found = test().registry().findBestConverterFor(listOfIntegersToListOfStrings());
+            Optional<Function<Bean2beanTask, Object>> found = test().registry().findBestConverterFor(listOfIntegersToListOfStrings());
             Object converterResult = found.get().apply(null);
             assertThat(converterResult).isEqualTo("List<Integer> -> List<String>");
           });
@@ -72,13 +72,13 @@ public class DefaultRegistryTest extends JavaSpec<B2bTestContext> {
         });
 
         it("finds the converter when the conversion vector matches the predicate",()->{
-          Optional<Function<ObjectConversion, Object>> found = test().registry().findBestConverterFor(listToList());
+          Optional<Function<Bean2beanTask, Object>> found = test().registry().findBestConverterFor(listToList());
           Object converterResult = found.get().apply(null);
           assertThat(converterResult).isEqualTo("input == output");
         });
 
         it("finds no converter if the conversion vector doesn't match the predicate",()->{
-          Optional<Function<ObjectConversion, Object>> found = test().registry().findBestConverterFor(objectToList());
+          Optional<Function<Bean2beanTask, Object>> found = test().registry().findBestConverterFor(objectToList());
           assertThat(found).isEmpty();
         });
 
@@ -88,13 +88,13 @@ public class DefaultRegistryTest extends JavaSpec<B2bTestContext> {
           });
 
           it("finds the first converter that matches the predicate",()->{
-            Optional<Function<ObjectConversion, Object>> found = test().registry().findBestConverterFor(listToList());
+            Optional<Function<Bean2beanTask, Object>> found = test().registry().findBestConverterFor(listToList());
             Object converterResult = found.get().apply(null);
             assertThat(converterResult).isEqualTo("input == output");
           });
 
           it("finds the second if the vector doesn't match the first predicate",()->{
-            Optional<Function<ObjectConversion, Object>> found = test().registry().findBestConverterFor(objectToList());
+            Optional<Function<Bean2beanTask, Object>> found = test().registry().findBestConverterFor(objectToList());
             Object converterResult = found.get().apply(null);
             assertThat(converterResult).isEqualTo("anything");
           });
@@ -106,13 +106,13 @@ public class DefaultRegistryTest extends JavaSpec<B2bTestContext> {
           });
 
           it("finds a matching vector based converter over any predicate based",()->{
-            Optional<Function<ObjectConversion, Object>> found = test().registry().findBestConverterFor(listToList());
+            Optional<Function<Bean2beanTask, Object>> found = test().registry().findBestConverterFor(listToList());
             Object converterResult = found.get().apply(null);
             assertThat(converterResult).isEqualTo("List -> List");
           });
 
           it("finds the predicate based converter if no vector based is applicable",()->{
-            Optional<Function<ObjectConversion, Object>> found = test().registry().findBestConverterFor(objectToObject());
+            Optional<Function<Bean2beanTask, Object>> found = test().registry().findBestConverterFor(objectToObject());
             Object converterResult = found.get().apply(null);
             assertThat(converterResult).isEqualTo("input == output");
           });
@@ -127,7 +127,7 @@ public class DefaultRegistryTest extends JavaSpec<B2bTestContext> {
           });
 
           it("finds no converter", () -> {
-            Optional<Function<ObjectConversion, Object>> found = test().registry().findBestConverterFor(listOfIntegersToListOfStrings());
+            Optional<Function<Bean2beanTask, Object>> found = test().registry().findBestConverterFor(listOfIntegersToListOfStrings());
             assertThat(found).isEmpty();
           });
 
@@ -139,7 +139,7 @@ public class DefaultRegistryTest extends JavaSpec<B2bTestContext> {
           });
 
           it("finds that converter", () -> {
-            Optional<Function<ObjectConversion, Object>> found = test().registry().findBestConverterFor(listOfIntegersToListOfStrings());
+            Optional<Function<Bean2beanTask, Object>> found = test().registry().findBestConverterFor(listOfIntegersToListOfStrings());
             Object converterResult = found.get().apply(null);
             assertThat(converterResult).isEqualTo("Object -> Object");
           });
@@ -152,7 +152,7 @@ public class DefaultRegistryTest extends JavaSpec<B2bTestContext> {
           });
 
           it("finds the more specific one", () -> {
-            Optional<Function<ObjectConversion, Object>> found = test().registry().findBestConverterFor(listOfIntegersToListOfStrings());
+            Optional<Function<Bean2beanTask, Object>> found = test().registry().findBestConverterFor(listOfIntegersToListOfStrings());
             Object converterResult = found.get().apply(null);
             assertThat(converterResult).isEqualTo("List -> List");
           });
@@ -165,7 +165,7 @@ public class DefaultRegistryTest extends JavaSpec<B2bTestContext> {
           });
 
           it("finds the one that's more specific to the expected output", () -> {
-            Optional<Function<ObjectConversion, Object>> found = test().registry().findBestConverterFor(listOfIntegersToListOfStrings());
+            Optional<Function<Bean2beanTask, Object>> found = test().registry().findBestConverterFor(listOfIntegersToListOfStrings());
             Object converterResult = found.get().apply(null);
             assertThat(converterResult).isEqualTo("Object -> List");
           });
@@ -178,7 +178,7 @@ public class DefaultRegistryTest extends JavaSpec<B2bTestContext> {
           });
 
           it("finds the one that's more specific to the expected output", () -> {
-            Optional<Function<ObjectConversion, Object>> found = test().registry().findBestConverterFor(listOfIntegersToListOfStrings());
+            Optional<Function<Bean2beanTask, Object>> found = test().registry().findBestConverterFor(listOfIntegersToListOfStrings());
             Object converterResult = found.get().apply(null);
             assertThat(converterResult).isEqualTo("Object -> List<String>");
           });

--- a/src/test/java/info/kfgodel/bean2bean/dsl/api/ConverterRegistrationOptionsTest.java
+++ b/src/test/java/info/kfgodel/bean2bean/dsl/api/ConverterRegistrationOptionsTest.java
@@ -2,6 +2,7 @@ package info.kfgodel.bean2bean.dsl.api;
 
 import ar.com.dgarcia.javaspec.api.JavaSpec;
 import ar.com.dgarcia.javaspec.api.JavaSpecRunner;
+import info.kfgodel.bean2bean.core.api.Bean2beanTask;
 import info.kfgodel.bean2bean.core.api.registry.DomainVector;
 import info.kfgodel.bean2bean.dsl.impl.Dsl;
 import info.kfgodel.bean2bean.other.references.BiFunctionRef;
@@ -45,7 +46,7 @@ public class ConverterRegistrationOptionsTest extends JavaSpec<B2bTestContext> {
         });
 
         it("accepts a bifunction reference that takes the dsl as second arg as a converter",()->{
-          test().configure().usingConverter(new BiFunctionRef<Object, B2bDsl, Object>((input, b2b)-> input) {});
+          test().configure().usingConverter(new BiFunctionRef<Object, Bean2beanTask, Object>((input, b2b)-> input) {});
           assertThat(test().dsl().convert().from("an object").to(Object.class)).isEqualTo("an object");
         });
 

--- a/src/test/java/info/kfgodel/bean2bean/dsl/api/converters/ArrayListToListOfStringsNestedConverter.java
+++ b/src/test/java/info/kfgodel/bean2bean/dsl/api/converters/ArrayListToListOfStringsNestedConverter.java
@@ -1,6 +1,6 @@
 package info.kfgodel.bean2bean.dsl.api.converters;
 
-import info.kfgodel.bean2bean.dsl.api.B2bDsl;
+import info.kfgodel.bean2bean.core.api.Bean2beanTask;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -13,13 +13,13 @@ import java.util.stream.Stream;
  * parts of the conversion to b2b
  * Date: 16/02/19 - 13:35
  */
-public class ArrayListToListOfStringsNestedConverter implements BiFunction<ArrayList, B2bDsl, List<String>> {
+public class ArrayListToListOfStringsNestedConverter implements BiFunction<ArrayList, Bean2beanTask, List<String>> {
 
   @Override
-  public List<String> apply(ArrayList arrayList, B2bDsl b2bDsl) {
+  public List<String> apply(ArrayList arrayList, Bean2beanTask task) {
     Stream<Integer> inputStream = arrayList.stream();
     return inputStream
-      .map(value -> b2bDsl.convert().from(value).to(String.class))
+      .map(value -> task.getDsl().convert().from(value).to(String.class))
       .collect(Collectors.toList());
   }
 


### PR DESCRIPTION
Prepares converter definitions for nesting conversion by adding the full task context as the 2nd arg on bifunction converters.
This allows getting more information from the task, than just the dsl