### PR TITLE
Use type as the more generic form of  target

### DIFF
--- a/src/main/java/info/kfgodel/bean2bean/dsl/api/CreateDsl.java
+++ b/src/main/java/info/kfgodel/bean2bean/dsl/api/CreateDsl.java
@@ -2,6 +2,8 @@ package info.kfgodel.bean2bean.dsl.api;
 
 import info.kfgodel.bean2bean.core.api.exceptions.Bean2BeanException;
 
+import java.lang.reflect.Type;
+
 /**
  * This type defines the available options for creating objects.<br>
  * Date: 16/02/19 - 18:57
@@ -13,10 +15,20 @@ public interface CreateDsl {
    *   This operation is equivalent to converting null to the expected type
    * @param expectedTypeClass The class that indicates the type of instance to be created
    * @param <T> The type of the output
-   * @return A new instance of teh expected type
+   * @return A new instance of the expected type
    * @throws Bean2BeanException If an error occurs during creation (like a missing converter)
    */
   <T> T anInstanceOf(Class<T> expectedTypeClass) throws Bean2BeanException;
+
+  /**
+   * Creates a new instance of the given type.<br>
+   *   This operation is equivalent to converting null to the expected type
+   * @param expectedType The type instance that indicates the expected type of instance to be created
+   * @param <T> The type of the output
+   * @return A new instance of the expected type
+   * @throws Bean2BeanException If an error occurs during creation (like a missing converter)
+   */
+  <T> T anInstanceOf(Type expectedType) throws Bean2BeanException;
 
 
   /**

--- a/src/main/java/info/kfgodel/bean2bean/dsl/api/SourceDefinedConversionDsl.java
+++ b/src/main/java/info/kfgodel/bean2bean/dsl/api/SourceDefinedConversionDsl.java
@@ -3,6 +3,8 @@ package info.kfgodel.bean2bean.dsl.api;
 import info.kfgodel.bean2bean.core.api.exceptions.Bean2BeanException;
 import info.kfgodel.bean2bean.other.references.TypeRef;
 
+import java.lang.reflect.Type;
+
 /**
  * This type defines the available options for a conversion once the
  * source object is defined
@@ -21,6 +23,17 @@ public interface SourceDefinedConversionDsl<I> {
    * or missing converter for the transformation)
    */
   <O> O to(Class<O> outputClass) throws Bean2BeanException;
+
+  /**
+   * Converts the source object into an instance of the expected type
+   * @param outputType The type instance that indicates the type of expected output for
+   *                    the conversion
+   * @param <O> The type of expected output
+   * @return The generated output after the conversion
+   * @throws Bean2BeanException If an error happened during conversion (like failed
+   * or missing converter for the transformation)
+   */
+  <O> O to(Type outputType) throws Bean2BeanException;
 
   /**
    * Converts the source object into an instance of the expected class

--- a/src/main/java/info/kfgodel/bean2bean/dsl/impl/CreateDslImpl.java
+++ b/src/main/java/info/kfgodel/bean2bean/dsl/impl/CreateDslImpl.java
@@ -6,6 +6,8 @@ import info.kfgodel.bean2bean.core.api.exceptions.CreationException;
 import info.kfgodel.bean2bean.dsl.api.B2bDsl;
 import info.kfgodel.bean2bean.dsl.api.CreateDsl;
 
+import java.lang.reflect.Type;
+
 /**
  * Implementation for the creation dsl
  * Date: 16/02/19 - 19:05
@@ -16,10 +18,15 @@ public class CreateDslImpl implements CreateDsl {
 
   @Override
   public <T> T anInstanceOf(Class<T> expectedTypeClass) throws Bean2BeanException {
+    return anInstanceOf((Type) expectedTypeClass);
+  }
+
+  @Override
+  public <T> T anInstanceOf(Type expectedType) throws Bean2BeanException {
     try {
-      return dsl.convert().from(null).to(expectedTypeClass);
+      return dsl.convert().from(null).to(expectedType);
     } catch (ConversionException e) {
-      throw new CreationException("Creation from null to " + expectedTypeClass.getTypeName() + " failed: " + e.getMessage(), expectedTypeClass ,e);
+      throw new CreationException("Creation from null to " + expectedType.getTypeName() + " failed: " + e.getMessage(), expectedType ,e);
     }
   }
 

--- a/src/main/java/info/kfgodel/bean2bean/dsl/impl/SourceDefinedConversionDslImpl.java
+++ b/src/main/java/info/kfgodel/bean2bean/dsl/impl/SourceDefinedConversionDslImpl.java
@@ -32,14 +32,18 @@ public class SourceDefinedConversionDslImpl<I> implements SourceDefinedConversio
 
   @Override
   public <O> O to(Class<O> outputClass) throws Bean2BeanException {
-    Domain targetDomain = domainFor(outputClass);
-    ObjectConversion conversion = createConversionTo(targetDomain);
-    return processConversion(conversion);
+    return to((Type) outputClass);
   }
 
   @Override
   public <O> O to(TypeRef<O> outputTypeRef) throws Bean2BeanException {
-    Domain targetDomain = domainFor(outputTypeRef.getReference());
+    Type reference = outputTypeRef.getReference();
+    return to(reference);
+  }
+
+  @Override
+  public <O> O to(Type outputType) throws Bean2BeanException {
+    Domain targetDomain = domainFor(outputType);
     ObjectConversion conversion = createConversionTo(targetDomain);
     return processConversion(conversion);
   }


### PR DESCRIPTION
Prepares the dsl to accept type as input for conversions