### PR TITLE
Enhace type argument extractor

### DIFF
--- a/src/main/java/info/kfgodel/bean2bean/core/impl/registry/domains/DomainVectorExtractor.java
+++ b/src/main/java/info/kfgodel/bean2bean/core/impl/registry/domains/DomainVectorExtractor.java
@@ -6,7 +6,7 @@ import info.kfgodel.bean2bean.other.references.BiFunctionRef;
 import info.kfgodel.bean2bean.other.references.ConsumerRef;
 import info.kfgodel.bean2bean.other.references.FunctionRef;
 import info.kfgodel.bean2bean.other.references.SupplierRef;
-import info.kfgodel.bean2bean.other.types.TypeArgumentExtractor;
+import info.kfgodel.bean2bean.other.types.extraction.TypeArgumentExtractor;
 
 import javax.lang.model.type.NullType;
 import java.lang.reflect.Type;

--- a/src/main/java/info/kfgodel/bean2bean/other/references/BiFunctionRef.java
+++ b/src/main/java/info/kfgodel/bean2bean/other/references/BiFunctionRef.java
@@ -1,6 +1,6 @@
 package info.kfgodel.bean2bean.other.references;
 
-import info.kfgodel.bean2bean.other.types.TypeArgumentExtractor;
+import info.kfgodel.bean2bean.other.types.extraction.TypeArgumentExtractor;
 
 import java.lang.reflect.Type;
 import java.util.function.BiFunction;

--- a/src/main/java/info/kfgodel/bean2bean/other/references/ConsumerRef.java
+++ b/src/main/java/info/kfgodel/bean2bean/other/references/ConsumerRef.java
@@ -1,6 +1,6 @@
 package info.kfgodel.bean2bean.other.references;
 
-import info.kfgodel.bean2bean.other.types.TypeArgumentExtractor;
+import info.kfgodel.bean2bean.other.types.extraction.TypeArgumentExtractor;
 
 import java.lang.reflect.Type;
 import java.util.function.Consumer;

--- a/src/main/java/info/kfgodel/bean2bean/other/references/FunctionRef.java
+++ b/src/main/java/info/kfgodel/bean2bean/other/references/FunctionRef.java
@@ -1,6 +1,6 @@
 package info.kfgodel.bean2bean.other.references;
 
-import info.kfgodel.bean2bean.other.types.TypeArgumentExtractor;
+import info.kfgodel.bean2bean.other.types.extraction.TypeArgumentExtractor;
 
 import java.lang.reflect.Type;
 import java.util.function.Function;

--- a/src/main/java/info/kfgodel/bean2bean/other/references/SupplierRef.java
+++ b/src/main/java/info/kfgodel/bean2bean/other/references/SupplierRef.java
@@ -1,6 +1,6 @@
 package info.kfgodel.bean2bean.other.references;
 
-import info.kfgodel.bean2bean.other.types.TypeArgumentExtractor;
+import info.kfgodel.bean2bean.other.types.extraction.TypeArgumentExtractor;
 
 import java.lang.reflect.Type;
 import java.util.function.Supplier;

--- a/src/main/java/info/kfgodel/bean2bean/other/references/TypeRef.java
+++ b/src/main/java/info/kfgodel/bean2bean/other/references/TypeRef.java
@@ -1,6 +1,6 @@
 package info.kfgodel.bean2bean.other.references;
 
-import info.kfgodel.bean2bean.other.types.TypeArgumentExtractor;
+import info.kfgodel.bean2bean.other.types.extraction.TypeArgumentExtractor;
 
 import java.lang.reflect.Type;
 

--- a/src/main/java/info/kfgodel/bean2bean/other/types/descriptors/ClassTypeDescriptor.java
+++ b/src/main/java/info/kfgodel/bean2bean/other/types/descriptors/ClassTypeDescriptor.java
@@ -1,0 +1,59 @@
+package info.kfgodel.bean2bean.other.types.descriptors;
+
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+/**
+ * This type describes instances of Class
+ * Date: 02/03/19 - 18:34
+ */
+public class ClassTypeDescriptor implements JavaTypeDescriptor {
+
+  private Class aClass;
+
+  public static ClassTypeDescriptor create(Class aClass) {
+    ClassTypeDescriptor descriptor = new ClassTypeDescriptor();
+    descriptor.aClass = aClass;
+    return descriptor;
+  }
+
+  @Override
+  public Type getType() {
+    return aClass;
+  }
+
+  @Override
+  public Type[] getTypeArguments() {
+    return NO_ARGUMENTS;
+  }
+
+  @Override
+  public Optional<Class> getErasuredType() {
+    return Optional.empty();
+  }
+
+  @Override
+  public Type[] getTypeArgumentsReplacingParametersWith(Map<TypeVariable, Type> typeParameterValues) {
+    return NO_ARGUMENTS;
+  }
+
+  @Override
+  public Stream<Type> getGenericSupertypes() {
+    Stream<Type> genericSuperclass = Optional.ofNullable(aClass.getGenericSuperclass())
+      .map(Stream::of)
+      .orElse(Stream.empty());
+    Stream<Type> genericInterfaces = Optional.ofNullable(aClass.getGenericInterfaces())
+      .map(Arrays::stream)
+      .orElse(Stream.empty());
+    return Stream.concat(genericSuperclass, genericInterfaces);
+  }
+
+  @Override
+  public String toString() {
+    return getType().getTypeName();
+  }
+}

--- a/src/main/java/info/kfgodel/bean2bean/other/types/descriptors/ClassTypeDescriptor.java
+++ b/src/main/java/info/kfgodel/bean2bean/other/types/descriptors/ClassTypeDescriptor.java
@@ -3,6 +3,7 @@ package info.kfgodel.bean2bean.other.types.descriptors;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -37,7 +38,7 @@ public class ClassTypeDescriptor implements JavaTypeDescriptor {
   }
 
   @Override
-  public Type[] getTypeArgumentsReplacingParametersWith(Map<TypeVariable, Type> typeParameterValues) {
+  public Type[] getTypeArgumentsBindedWith(Map<TypeVariable, Type> typeParameterBindings) {
     return NO_ARGUMENTS;
   }
 
@@ -50,6 +51,25 @@ public class ClassTypeDescriptor implements JavaTypeDescriptor {
       .map(Arrays::stream)
       .orElse(Stream.empty());
     return Stream.concat(genericSuperclass, genericInterfaces);
+  }
+
+  @Override
+  public Map<TypeVariable, Type> calculateTypeVariableBindingsFor(Type[] actualArguments) {
+    TypeVariable[] typeParameters = aClass.getTypeParameters();
+    if(actualArguments.length != typeParameters.length){
+      throw new IllegalArgumentException(
+        "The class["+aClass+"] can't bind its parameters " + Arrays.toString(typeParameters)
+          + " to the arguments " + Arrays.toString(actualArguments) + ". Arrays don't match"
+      );
+    }
+    Map<TypeVariable, Type> parameterValues = new LinkedHashMap<>();
+    for (int i = 0; i < typeParameters.length; i++) {
+      TypeVariable typeParameter = typeParameters[i];
+      Type typeArgument = actualArguments[i];
+      parameterValues.put(typeParameter, typeArgument);
+    }
+    return parameterValues;
+
   }
 
   @Override

--- a/src/main/java/info/kfgodel/bean2bean/other/types/descriptors/JavaTypeDescriptor.java
+++ b/src/main/java/info/kfgodel/bean2bean/other/types/descriptors/JavaTypeDescriptor.java
@@ -1,0 +1,72 @@
+package info.kfgodel.bean2bean.other.types.descriptors;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+/**
+ * This type defines a common protocol for the different kinds of type representation on the java language
+ * so we can extract the type information regardless of the specific type.<br>
+ *   This can be seen as adding the methods that are missing on {@link java.lang.reflect.Type}
+ *
+ * Date: 02/03/19 - 18:32
+ */
+public interface JavaTypeDescriptor {
+  /**
+   * Used for types with no arguments
+   */
+  Type[] NO_ARGUMENTS = new Type[0];
+
+  /**
+   * @return The type that is described
+   */
+  Type getType();
+
+  /**
+   * Returns the type arguments used on this type if any. An empty array is returned for types
+   * that don't have type parameters, or are not parameterized with actual arguments
+   * @return The type arguments for the described type
+   */
+  Type[] getTypeArguments();
+
+  /**
+   * Returns the type that results from stripping this type arguments.<br>
+   *   This is only applicable for types that have arguments, for the rest it results on
+   *   an empty optional
+   * @return The raw type for this type or empty
+   */
+  Optional<Class> getErasuredType();
+
+  /**
+   * Returns the arguments of this type replaced with the values provided for each variable
+   * @param typeParameterValues The type value for each type variable that may be used
+   *                            as argument on this type
+   * @return The type argument with replaced values
+   */
+  Type[] getTypeArgumentsReplacingParametersWith(Map<TypeVariable, Type> typeParameterValues);
+
+  /**
+   * Returns the types that are declared as generic supertypes of this instance.<br>
+   *   Only instances of classes have generic supertypes
+   * @return The generic superclass and interfaces or empty for non class types
+   */
+  Stream<Type> getGenericSupertypes();
+
+  /**
+   * Creates the descriptor that best describes the given type instance
+   * @param type The type to describe
+   * @return The descriptor specific for that type
+   */
+  static JavaTypeDescriptor createFor(Type type) {
+    if(type instanceof Class){
+      return ClassTypeDescriptor.create((Class) type);
+    }else if(type instanceof ParameterizedType){
+      return ParameterizedTypeDescriptor.create((ParameterizedType)type);
+    }
+    return VariableOrWildcardTypeDescriptor.create(type);
+  }
+
+}

--- a/src/main/java/info/kfgodel/bean2bean/other/types/descriptors/JavaTypeDescriptor.java
+++ b/src/main/java/info/kfgodel/bean2bean/other/types/descriptors/JavaTypeDescriptor.java
@@ -41,12 +41,12 @@ public interface JavaTypeDescriptor {
   Optional<Class> getErasuredType();
 
   /**
-   * Returns the arguments of this type replaced with the values provided for each variable
-   * @param typeParameterValues The type value for each type variable that may be used
-   *                            as argument on this type
-   * @return The type argument with replaced values
+   * Returns the type arguments of this type binding the type variables with the given bindings, so
+   * the end result has type variables replaced with their actual type value
+   * @param typeParameterBindings The type value for each type variable on this type
+   * @return The type arguments solved after replacing the variables on the bindings
    */
-  Type[] getTypeArgumentsReplacingParametersWith(Map<TypeVariable, Type> typeParameterValues);
+  Type[] getTypeArgumentsBindedWith(Map<TypeVariable, Type> typeParameterBindings);
 
   /**
    * Returns the types that are declared as generic supertypes of this instance.<br>
@@ -54,6 +54,15 @@ public interface JavaTypeDescriptor {
    * @return The generic superclass and interfaces or empty for non class types
    */
   Stream<Type> getGenericSupertypes();
+
+  /**
+   * Calculates the map of bindings required on this type to replace each type variable with the given argument.<br>
+   *   The correspondence between variable and variable is done by position of the arrays (parameters and arguments).<br>
+   *   For types that don't have parameters and empty map is returned
+   * @param typeArguments The arguments to bind each variable to
+   * @return The map of bindings between this type parameters and the given arguments
+   */
+  Map<TypeVariable, Type> calculateTypeVariableBindingsFor(Type[] typeArguments);
 
   /**
    * Creates the descriptor that best describes the given type instance
@@ -68,5 +77,6 @@ public interface JavaTypeDescriptor {
     }
     return VariableOrWildcardTypeDescriptor.create(type);
   }
+
 
 }

--- a/src/main/java/info/kfgodel/bean2bean/other/types/descriptors/ParameterizedTypeDescriptor.java
+++ b/src/main/java/info/kfgodel/bean2bean/other/types/descriptors/ParameterizedTypeDescriptor.java
@@ -3,6 +3,7 @@ package info.kfgodel.bean2bean.other.types.descriptors;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -39,13 +40,13 @@ public class ParameterizedTypeDescriptor implements JavaTypeDescriptor {
   }
 
   @Override
-  public Type[] getTypeArgumentsReplacingParametersWith(Map<TypeVariable, Type> typeParameterValues) {
+  public Type[] getTypeArgumentsBindedWith(Map<TypeVariable, Type> typeParameterBindings) {
     Type[] declaredArguments = getTypeArguments();
     Type[] replacedArguments = new Type[declaredArguments.length];
     for (int i = 0; i < declaredArguments.length; i++) {
-      Type declared = declaredArguments[i];
-      Optional<Type> replacement = Optional.ofNullable(typeParameterValues.get(declared));
-      replacedArguments[i] = replacement.orElse(declared);
+      Type declaredArgument = declaredArguments[i];
+      Optional<Type> replacementArgument = Optional.ofNullable(typeParameterBindings.get(declaredArgument));
+      replacedArguments[i] = replacementArgument.orElse(declaredArgument);
     }
     return replacedArguments;
   }
@@ -53,6 +54,11 @@ public class ParameterizedTypeDescriptor implements JavaTypeDescriptor {
   @Override
   public Stream<Type> getGenericSupertypes() {
     return Stream.empty();
+  }
+
+  @Override
+  public Map<TypeVariable, Type> calculateTypeVariableBindingsFor(Type[] typeArguments) {
+    return Collections.emptyMap();
   }
 
   @Override

--- a/src/main/java/info/kfgodel/bean2bean/other/types/descriptors/ParameterizedTypeDescriptor.java
+++ b/src/main/java/info/kfgodel/bean2bean/other/types/descriptors/ParameterizedTypeDescriptor.java
@@ -1,0 +1,63 @@
+package info.kfgodel.bean2bean.other.types.descriptors;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+/**
+ * This type describes instances of {@link java.lang.reflect.ParameterizedType}
+ * Date: 02/03/19 - 18:35
+ */
+public class ParameterizedTypeDescriptor implements JavaTypeDescriptor {
+
+  private ParameterizedType aType;
+
+  public static ParameterizedTypeDescriptor create(ParameterizedType aType) {
+    ParameterizedTypeDescriptor descriptor = new ParameterizedTypeDescriptor();
+    descriptor.aType = aType;
+    return descriptor;
+  }
+
+  @Override
+  public Type getType() {
+    return aType;
+  }
+
+  @Override
+  public Type[] getTypeArguments() {
+    return aType.getActualTypeArguments();
+  }
+
+  @Override
+  public Optional<Class> getErasuredType() {
+    Type rawType = aType.getRawType();
+    Class rawClass = (Class) rawType;
+    return Optional.of(rawClass);
+  }
+
+  @Override
+  public Type[] getTypeArgumentsReplacingParametersWith(Map<TypeVariable, Type> typeParameterValues) {
+    Type[] declaredArguments = getTypeArguments();
+    Type[] replacedArguments = new Type[declaredArguments.length];
+    for (int i = 0; i < declaredArguments.length; i++) {
+      Type declared = declaredArguments[i];
+      Optional<Type> replacement = Optional.ofNullable(typeParameterValues.get(declared));
+      replacedArguments[i] = replacement.orElse(declared);
+    }
+    return replacedArguments;
+  }
+
+  @Override
+  public Stream<Type> getGenericSupertypes() {
+    return Stream.empty();
+  }
+
+  @Override
+  public String toString() {
+    return getType().getTypeName();
+  }
+
+}

--- a/src/main/java/info/kfgodel/bean2bean/other/types/descriptors/VariableOrWildcardTypeDescriptor.java
+++ b/src/main/java/info/kfgodel/bean2bean/other/types/descriptors/VariableOrWildcardTypeDescriptor.java
@@ -1,0 +1,53 @@
+package info.kfgodel.bean2bean.other.types.descriptors;
+
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+/**
+ * This type describes {@link java.lang.reflect.TypeVariable} types or {@link java.lang.reflect.WildcardType} types
+ * Date: 02/03/19 - 18:39
+ */
+public class VariableOrWildcardTypeDescriptor implements JavaTypeDescriptor {
+
+  private Type aType;
+
+  public static VariableOrWildcardTypeDescriptor create(Type aType) {
+    VariableOrWildcardTypeDescriptor descriptor = new VariableOrWildcardTypeDescriptor();
+    descriptor.aType = aType;
+    return descriptor;
+  }
+
+  @Override
+  public Type getType() {
+    return aType;
+  }
+
+  @Override
+  public Type[] getTypeArguments() {
+    return JavaTypeDescriptor.NO_ARGUMENTS;
+  }
+
+  @Override
+  public Optional<Class> getErasuredType() {
+    return Optional.empty();
+  }
+
+  @Override
+  public Type[] getTypeArgumentsReplacingParametersWith(Map<TypeVariable, Type> typeParameterValues) {
+    return NO_ARGUMENTS;
+  }
+
+  @Override
+  public Stream<Type> getGenericSupertypes() {
+    return Stream.empty();
+  }
+
+  @Override
+  public String toString() {
+    return getType().getTypeName();
+  }
+
+}

--- a/src/main/java/info/kfgodel/bean2bean/other/types/descriptors/VariableOrWildcardTypeDescriptor.java
+++ b/src/main/java/info/kfgodel/bean2bean/other/types/descriptors/VariableOrWildcardTypeDescriptor.java
@@ -2,6 +2,7 @@ package info.kfgodel.bean2bean.other.types.descriptors;
 
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -36,13 +37,18 @@ public class VariableOrWildcardTypeDescriptor implements JavaTypeDescriptor {
   }
 
   @Override
-  public Type[] getTypeArgumentsReplacingParametersWith(Map<TypeVariable, Type> typeParameterValues) {
+  public Type[] getTypeArgumentsBindedWith(Map<TypeVariable, Type> typeParameterBindings) {
     return NO_ARGUMENTS;
   }
 
   @Override
   public Stream<Type> getGenericSupertypes() {
     return Stream.empty();
+  }
+
+  @Override
+  public Map<TypeVariable, Type> calculateTypeVariableBindingsFor(Type[] typeArguments) {
+    return Collections.emptyMap();
   }
 
   @Override

--- a/src/main/java/info/kfgodel/bean2bean/other/types/extraction/TypeArgumentExtraction.java
+++ b/src/main/java/info/kfgodel/bean2bean/other/types/extraction/TypeArgumentExtraction.java
@@ -1,0 +1,87 @@
+package info.kfgodel.bean2bean.other.types.extraction;
+
+import info.kfgodel.bean2bean.other.types.SupertypeSpliterator;
+import info.kfgodel.bean2bean.other.types.descriptors.JavaTypeDescriptor;
+
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+/**
+ * This class represents a single type argument extraction which needs to carry all the
+ * type variable replacement with their actual values
+ * Date: 28/02/19 - 23:31
+ */
+public class TypeArgumentExtraction {
+
+  private Type concreteType;
+  private Map<Type, Type[]> argumentsByType;
+
+  public static TypeArgumentExtraction create(Type concreteType) {
+    TypeArgumentExtraction extraction = new TypeArgumentExtraction();
+    extraction.concreteType = concreteType;
+    extraction.argumentsByType = new LinkedHashMap<>();
+    extraction.calculateTypeArguments();
+    return extraction;
+  }
+
+  private void calculateTypeArguments() {
+    SupertypeSpliterator.createAsStream(concreteType)
+      .map(JavaTypeDescriptor::createFor)
+      .forEach(this::discoverActualArgumentsFor);
+  }
+
+  private void discoverActualArgumentsFor(JavaTypeDescriptor typeDescriptor) {
+    Type[] typeArguments = typeDescriptor.getTypeArguments();
+    registerArguments(typeDescriptor, typeArguments);
+  }
+
+  private void registerArguments(JavaTypeDescriptor typeDescriptor, Type[] typeArguments) {
+    Type aType = typeDescriptor.getType();
+    Type[] registeredArguments = argumentsByType.putIfAbsent(aType, typeArguments);
+    if(registeredArguments != null){
+      // No need to run the rest, the hierarchy was aleready registered
+      return;
+    }
+
+    Optional<Class> parametrizableClass = typeDescriptor.getErasuredType();
+    parametrizableClass.ifPresent((clase) -> {
+      JavaTypeDescriptor erasuredTypeDescriptor = JavaTypeDescriptor.createFor(clase);
+      registerArguments(erasuredTypeDescriptor, typeArguments);
+
+      Map<TypeVariable, Type> typeParameterValues = this.getTypeParameterValues(clase, typeArguments);
+      Stream<Type> superTypes = erasuredTypeDescriptor.getGenericSupertypes();
+      superTypes.forEach(superType ->{
+        JavaTypeDescriptor superTypeDescriptor = JavaTypeDescriptor.createFor(superType);
+        Type[] replacedArguments = superTypeDescriptor.getTypeArgumentsReplacingParametersWith(typeParameterValues);
+        this.registerArguments(superTypeDescriptor, replacedArguments);
+      });
+    });
+  }
+
+  private Map<TypeVariable, Type> getTypeParameterValues(Class clase, Type[] typeArguments) {
+    TypeVariable[] typeParameters = clase.getTypeParameters();
+    if(typeArguments.length != typeParameters.length){
+      throw new IllegalStateException("How does class["+clase+"] have parameters " + Arrays.toString(typeParameters) + " and mismatching args " + Arrays.toString(typeArguments));
+    }
+    Map<TypeVariable, Type> parameterReplacements = new LinkedHashMap<>();
+    for (int i = 0; i < typeParameters.length; i++) {
+      TypeVariable typeParameter = typeParameters[i];
+      Type typeArgument = typeArguments[i];
+      parameterReplacements.put(typeParameter, typeArgument);
+    }
+    return parameterReplacements;
+  }
+
+  public Stream<Type> getArgumentsFor(Type parametrizableClass) {
+    Type[] actualArguments = argumentsByType.get(parametrizableClass);
+    if (argumentsByType == null) {
+      return Stream.empty();
+    }
+    return Arrays.stream(actualArguments);
+  }
+}

--- a/src/test/java/info/kfgodel/bean2bean/other/NoArgFunction.java
+++ b/src/test/java/info/kfgodel/bean2bean/other/NoArgFunction.java
@@ -1,7 +1,7 @@
 package info.kfgodel.bean2bean.other;
 
 
-import info.kfgodel.bean2bean.other.types.TypeArgumentExtractor;
+import info.kfgodel.bean2bean.other.types.extraction.TypeArgumentExtractor;
 
 import java.util.function.Function;
 

--- a/src/test/java/info/kfgodel/bean2bean/other/TypeArgumentExtractorTest.java
+++ b/src/test/java/info/kfgodel/bean2bean/other/TypeArgumentExtractorTest.java
@@ -3,16 +3,15 @@ package info.kfgodel.bean2bean.other;
 import ar.com.dgarcia.javaspec.api.JavaSpec;
 import ar.com.dgarcia.javaspec.api.JavaSpecRunner;
 import com.google.common.collect.Lists;
-import info.kfgodel.bean2bean.dsl.api.converters.StringArrayGenerator;
-import info.kfgodel.bean2bean.other.types.TypeArgumentExtractor;
+import info.kfgodel.bean2bean.other.types.extraction.TypeArgumentExtractor;
 import org.junit.runner.RunWith;
 
 import java.lang.reflect.Type;
-import java.lang.reflect.TypeVariable;
-import java.util.Collection;
+import java.util.AbstractMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
-import java.util.function.Function;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -30,24 +29,79 @@ public class TypeArgumentExtractorTest extends JavaSpec<TypeRefTestContext> {
       test().argumentExtractor(TypeArgumentExtractor::create);
 
       it("can extract the actual type arguments used to parameterize the supertype of a class", () -> {
-        Stream<Type> arguments = test().argumentExtractor().getArgumentsUsedFor(Function.class, StringArrayGenerator.class);
+        Stream<Type> arguments = test().argumentExtractor().getArgumentsUsedFor(Map.class, MapOfIntegersToString.class);
         assertThat(arguments.collect(Collectors.toList()))
-          .isEqualTo(Lists.newArrayList(Integer.class, String[].class));
+          .isEqualTo(Lists.newArrayList(Integer.class, String.class));
       });
 
       it("returns empty if the concrete class doesn't have type arguments for the supertype",()->{
-        Stream<Type> arguments = test().argumentExtractor().getArgumentsUsedFor(Function.class, NoArgFunction.class);
+        Stream<Type> arguments = test().argumentExtractor().getArgumentsUsedFor(Map.class, MissingArgumentsMap.class);
         assertThat(arguments.count()).isEqualTo(0);
       });
 
       it("offers a facility method when there's only 1 argument",()->{
-        Optional<Type> argument = test().argumentExtractor().getArgumentUsedFor(Collection.class, List.class);
-        TypeVariable actual = (TypeVariable) argument.get();
-        assertThat(actual.getName()).isEqualTo("E");
+        Optional<Type> argument = test().argumentExtractor().getArgumentUsedFor(Set.class, SetOfStrings.class);
+        assertThat(argument.get()).isEqualTo(String.class);
       });
+
+      describe("when the argument is not directly defined", () -> {
+        
+        it("can deduce the indirectly defined type arguments",()->{
+          Stream<Type> arguments = test().argumentExtractor().getArgumentsUsedFor(Map.class, IndirectlyParameterizedMap.class);
+          assertThat(arguments.collect(Collectors.toList()))
+            .isEqualTo(Lists.newArrayList(Integer.class, String.class));
+        });
+
+        it("can deduce the arguments with more than one level of indirection",()->{
+          Optional<Type> argument = test().argumentExtractor().getArgumentUsedFor(Iterable.class, SetOfStrings.class);
+          assertThat(argument.get()).isEqualTo(String.class);
+        });
+
+        it("will deduce type variable replacements over the hierarchy",()->{
+          Stream<Type> arguments = test().argumentExtractor().getArgumentsUsedFor(Map.class, SubClassOfMapOfIntegersToVariable.class);
+          List<Type> typeArguments = arguments.collect(Collectors.toList());
+          assertThat(typeArguments.get(0)).isEqualTo(Integer.class);
+          assertThat(typeArguments.get(1).getTypeName()).isEqualTo("Replaced");
+        });
+
+        it("can deduce actual arguments even when more than one definition is done in the hierarchy",()->{
+          Stream<Type> arguments = test().argumentExtractor().getArgumentsUsedFor(Map.class, MultiArgumentDefinition.class);
+          assertThat(arguments.collect(Collectors.toList()))
+            .isEqualTo(Lists.newArrayList(Integer.class, String.class));
+        });
+
+        it("deduces the actual argument, even if it's a variable",()->{
+          Stream<Type> arguments = test().argumentExtractor().getArgumentsUsedFor(Map.class, getVariableArgType());
+          List<Type> typeArguments = arguments.collect(Collectors.toList());
+          assertThat(typeArguments.get(0)).isEqualTo(Integer.class);
+          assertThat(typeArguments.get(1).getTypeName()).isEqualTo("DefinedInMethod");
+        });
+
+      });
+
 
 
     });
 
   }
+
+  public abstract static class MapOfIntegersToString implements Map<Integer, String> {}
+  public abstract static class MissingArgumentsMap implements Map{}
+  public abstract static class SetOfStrings implements Set<String> {}
+  public abstract static class IndirectlyParameterizedMap extends AbstractMap<Integer, String> {}
+
+  public abstract static class SubClassOfMapOfIntegersToVariable<Replaced> extends AbstractMap<Integer, Replaced> {}
+
+  public interface MapOfVariableKeyToStrings<K> extends Map<K, String> {}
+  public interface MapOfIntegerToVariableValue<V> extends Map<Integer, V> {}
+  public abstract static class MultiArgumentDefinition
+    implements MapOfVariableKeyToStrings<Integer>, MapOfIntegerToVariableValue<String>  {}
+
+
+  public <DefinedInMethod> Type getVariableArgType(){
+    abstract class MapOfIntegersToE extends AbstractMap<Integer, DefinedInMethod>{};
+    return MapOfIntegersToE.class;
+  }
+
+
 }

--- a/src/test/java/info/kfgodel/bean2bean/other/TypeRefTest.java
+++ b/src/test/java/info/kfgodel/bean2bean/other/TypeRefTest.java
@@ -7,7 +7,6 @@ import org.junit.runner.RunWith;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
-import java.lang.reflect.TypeVariable;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -52,8 +51,8 @@ public class TypeRefTest extends JavaSpec<TypeRefTestContext> {
       describe("when more than one level of inheritance is used", () -> {
         test().typeRef(() -> new OtherSubTypeRef<String>() {});
 
-        it("only retains as reference the type used to parameterize TypeRef, not its subclasses",()->{
-          assertThat(test().typeRef().getReference()).isInstanceOf(TypeVariable.class);
+        it("retains the indirectly defined type argument",()->{
+          assertThat(test().typeRef().getReference()).isEqualTo(String.class);
         });
       });
     });

--- a/src/test/java/info/kfgodel/bean2bean/other/TypeRefTestContext.java
+++ b/src/test/java/info/kfgodel/bean2bean/other/TypeRefTestContext.java
@@ -7,7 +7,7 @@ import info.kfgodel.bean2bean.other.references.FunctionRef;
 import info.kfgodel.bean2bean.other.references.SupplierRef;
 import info.kfgodel.bean2bean.other.references.TypeRef;
 import info.kfgodel.bean2bean.other.types.SupertypeSpliterator;
-import info.kfgodel.bean2bean.other.types.TypeArgumentExtractor;
+import info.kfgodel.bean2bean.other.types.extraction.TypeArgumentExtractor;
 
 import java.lang.reflect.Type;
 import java.util.List;


### PR DESCRIPTION
Improves the type extractor to propagate actual type arguments up in the hiearchy, so a parameterized class has the most specific converter possible