### PR TITLE
Add generic array supertypes on the spliterator

### DIFF
--- a/src/main/java/info/kfgodel/bean2bean/other/types/SupertypeSpliterator.java
+++ b/src/main/java/info/kfgodel/bean2bean/other/types/SupertypeSpliterator.java
@@ -1,8 +1,10 @@
 package info.kfgodel.bean2bean.other.types;
 
+import info.kfgodel.bean2bean.other.types.descriptors.JavaTypeDescriptor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
@@ -10,6 +12,7 @@ import java.lang.reflect.WildcardType;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.LinkedList;
+import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
 import java.util.Spliterator;
@@ -83,6 +86,8 @@ public class SupertypeSpliterator implements Spliterator<Type> {
       enqueueSupertypesOf((TypeVariable)visitedType);
     }else if(visitedType instanceof WildcardType){
       enqueueSupertypesOf((WildcardType)visitedType);
+    }else if(visitedType instanceof GenericArrayType){
+      enqueueSupertypesOf((GenericArrayType)visitedType);
     }else{
       // For the rest of types we don't have a way to explore supertypes (yet)
       LOG.warn("No known methods for obtaining the supertypes of: {}", visitedType);
@@ -101,6 +106,12 @@ public class SupertypeSpliterator implements Spliterator<Type> {
   private void enqueueSupertypesOf(WildcardType visitedType){
     Arrays.stream(visitedType.getUpperBounds())
       .forEach(this::enqueue);
+
+  }
+  private void enqueueSupertypesOf(GenericArrayType visitedType){
+    Optional<Class> assignableClass = JavaTypeDescriptor.createFor(visitedType)
+      .getAssignableClass();
+    assignableClass.ifPresent(this::enqueue);
   }
 
   private void enqueueSupertypesOf(Class visitedClass){

--- a/src/main/java/info/kfgodel/bean2bean/other/types/descriptors/TypeDescriptorSupport.java
+++ b/src/main/java/info/kfgodel/bean2bean/other/types/descriptors/TypeDescriptorSupport.java
@@ -47,7 +47,7 @@ public abstract class TypeDescriptorSupport implements JavaTypeDescriptor {
 
   @Override
   public Optional<Class> getInstantiableClass() {
-    return Optional.empty();
+    return getAssignableClass();
   }
 
   @Override

--- a/src/test/java/info/kfgodel/bean2bean/other/SupertypeSpliteratorTest.java
+++ b/src/test/java/info/kfgodel/bean2bean/other/SupertypeSpliteratorTest.java
@@ -113,6 +113,19 @@ public class SupertypeSpliteratorTest<E> extends JavaSpec<TypeRefTestContext> {
           });
         });
 
+        describe("given a parameterized generic array", () -> {
+          test().type(this::getParameterizedArray);
+
+          it("allows access to its super type hierarchy including type arguments only for initial type",()->{
+            assertThat(test().supertypes()).isEqualTo(Lists.newArrayList(
+              "java.util.List<java.lang.String>[]",
+              "java.util.List[]",
+              "java.lang.Cloneable",
+              "java.io.Serializable",
+              "java.lang.Object"
+            ));
+          });
+        });
 
       });
 
@@ -126,4 +139,9 @@ public class SupertypeSpliteratorTest<E> extends JavaSpec<TypeRefTestContext> {
   private <E extends String & Iterable> Type getMultiUpperBondedTypeVariable() {
     return new TypeRef<E>() {}.getReference();
   }
+
+  private Type getParameterizedArray() {
+    return new TypeRef<List<String>[]>() {}.getReference();
+  }
+
 }


### PR DESCRIPTION
Addresses https://github.com/kfgodel/bean2bean/issues/71
Allows better domain descriptions for generic arrays