### PR TITLE
Add lambda references for converter registration

### DIFF
--- a/src/main/java/info/kfgodel/bean2bean/dsl/api/scopes/ScopedConfigureDsl.java
+++ b/src/main/java/info/kfgodel/bean2bean/dsl/api/scopes/ScopedConfigureDsl.java
@@ -1,6 +1,10 @@
 package info.kfgodel.bean2bean.dsl.api.scopes;
 
 import info.kfgodel.bean2bean.core.api.Bean2beanTask;
+import info.kfgodel.bean2bean.other.references.BiFunctionRef;
+import info.kfgodel.bean2bean.other.references.ConsumerRef;
+import info.kfgodel.bean2bean.other.references.FunctionRef;
+import info.kfgodel.bean2bean.other.references.SupplierRef;
 
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
@@ -47,4 +51,36 @@ public interface ScopedConfigureDsl {
    */
   <I> ScopedConfigureDsl useConverter(Consumer<I> converterFunction);
 
+  /**
+   * Registers a function through its reference to be used as converter between the function input-output types.<br>
+   *   This method variant allows using a reference to disambiguate lambda parameters (useful for method references with
+   *   overloaded versions)
+   * @param converterFunctionRef The reference to the function used as converter
+   * @return This instance for method chaining
+   */
+  <I,O> ScopedConfigureDsl useConverter(FunctionRef<I,O> converterFunctionRef);
+
+  /**
+   * Registers a converter function though its reference that will need access to b2b dsl as part of the conversion
+   *  process. Usually for delegating the conversion of one or more parts of the original object (nesting conversions).
+   * @param converterFunction The function to use as converter
+   * @return This instance for method chaining
+   */
+  <I,O> ScopedConfigureDsl useConverter(BiFunctionRef<I,Bean2beanTask,O> converterFunction);
+
+  /**
+   * Registers a converter lambda through its reference that requires no parameters as input for the conversion.<br>
+   *   Usually these converters are used as generators to instantiate other types
+   * @param converterFunction The function to use a generator
+   * @return This instance for method chaining
+   */
+  <O> ScopedConfigureDsl useConverter(SupplierRef<O> converterFunction);
+
+  /**
+   * Registers a converter lambda through its reference that generates no output as result of the conversion.<br>
+   *   Usually these converters are used as destructors of intances to release resources
+   * @param converterFunction The function to use as destructor
+   * @return This instance for method chaining
+   */
+  <I> ScopedConfigureDsl useConverter(ConsumerRef<I> converterFunction);
 }

--- a/src/main/java/info/kfgodel/bean2bean/dsl/impl/scopes/DomainVectorScopedConfigureDsl.java
+++ b/src/main/java/info/kfgodel/bean2bean/dsl/impl/scopes/DomainVectorScopedConfigureDsl.java
@@ -10,6 +10,10 @@ import info.kfgodel.bean2bean.core.impl.registry.definitions.VectorDefinition;
 import info.kfgodel.bean2bean.dsl.api.ConfigureDsl;
 import info.kfgodel.bean2bean.dsl.api.scopes.ScopedConfigureDsl;
 import info.kfgodel.bean2bean.dsl.impl.ConfigureDslImpl;
+import info.kfgodel.bean2bean.other.references.BiFunctionRef;
+import info.kfgodel.bean2bean.other.references.ConsumerRef;
+import info.kfgodel.bean2bean.other.references.FunctionRef;
+import info.kfgodel.bean2bean.other.references.SupplierRef;
 
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
@@ -54,6 +58,26 @@ public class DomainVectorScopedConfigureDsl implements ScopedConfigureDsl {
   public <I> ScopedConfigureDsl useConverter(Consumer<I> converterFunction) {
     ConsumerAdapterConverter converter = ConsumerAdapterConverter.create(converterFunction);
     return usingConverterFor(converter);
+  }
+
+  @Override
+  public <I, O> ScopedConfigureDsl useConverter(FunctionRef<I, O> converterFunctionRef) {
+    return useConverter(converterFunctionRef.getFunction());
+  }
+
+  @Override
+  public <I, O> ScopedConfigureDsl useConverter(BiFunctionRef<I, Bean2beanTask, O> converterFunction) {
+    return useConverter(converterFunction.getBiFunction());
+  }
+
+  @Override
+  public <O> ScopedConfigureDsl useConverter(SupplierRef<O> converterFunction) {
+    return useConverter(converterFunction.getSupplier());
+  }
+
+  @Override
+  public <I> ScopedConfigureDsl useConverter(ConsumerRef<I> converterFunction) {
+    return useConverter(converterFunction.getConsumer());
   }
 
   private ConfigureDsl usingConverterFor(Function<Bean2beanTask, Object> converter) {

--- a/src/main/java/info/kfgodel/bean2bean/dsl/impl/scopes/PredicateScopedConfigureDsl.java
+++ b/src/main/java/info/kfgodel/bean2bean/dsl/impl/scopes/PredicateScopedConfigureDsl.java
@@ -10,6 +10,10 @@ import info.kfgodel.bean2bean.core.impl.registry.definitions.PredicateDefinition
 import info.kfgodel.bean2bean.dsl.api.ConfigureDsl;
 import info.kfgodel.bean2bean.dsl.api.scopes.ScopedConfigureDsl;
 import info.kfgodel.bean2bean.dsl.impl.ConfigureDslImpl;
+import info.kfgodel.bean2bean.other.references.BiFunctionRef;
+import info.kfgodel.bean2bean.other.references.ConsumerRef;
+import info.kfgodel.bean2bean.other.references.FunctionRef;
+import info.kfgodel.bean2bean.other.references.SupplierRef;
 
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
@@ -55,6 +59,26 @@ public class PredicateScopedConfigureDsl implements ScopedConfigureDsl {
   public <I> ConfigureDsl useConverter(Consumer<I> converterFunction) {
     ConsumerAdapterConverter converter = ConsumerAdapterConverter.create(converterFunction);
     return usingConverterFor(converter);
+  }
+
+  @Override
+  public <I, O> ScopedConfigureDsl useConverter(FunctionRef<I, O> converterFunctionRef) {
+    return useConverter(converterFunctionRef.getFunction());
+  }
+
+  @Override
+  public <I, O> ScopedConfigureDsl useConverter(BiFunctionRef<I, Bean2beanTask, O> converterFunction) {
+    return useConverter(converterFunction.getBiFunction());
+  }
+
+  @Override
+  public <O> ScopedConfigureDsl useConverter(SupplierRef<O> converterFunction) {
+    return useConverter(converterFunction.getSupplier());
+  }
+
+  @Override
+  public <I> ScopedConfigureDsl useConverter(ConsumerRef<I> converterFunction) {
+    return useConverter(converterFunction.getConsumer());
   }
 
   private ConfigureDsl usingConverterFor(Function<Bean2beanTask, Object> converter) {

--- a/src/test/java/info/kfgodel/bean2bean/dsl/api/ConverterRegistrationOptionsTest.java
+++ b/src/test/java/info/kfgodel/bean2bean/dsl/api/ConverterRegistrationOptionsTest.java
@@ -27,140 +27,238 @@ public class ConverterRegistrationOptionsTest extends JavaSpec<B2bTestContext> {
       test().configure(()-> test().dsl().configure());
       test().dsl(Dsl::create);
 
-      describe("used to register implicitly scoped converters", () -> {
+      describe("scoping implicitly by the input and output types", () -> {
+        describe("for lambda instances", () -> {
 
-        it("accepts a function as converter", () -> {
-          test().configure().useConverter((in) -> in);
-          assertThat(test().dsl().convert().from("an object").to(Object.class)).isEqualTo("an object");
-        });
-
-        it("accepts a bifunction that takes the dsl as second arg as a converter",()->{
-          test().configure().useConverter((input, b2b)-> input);
-          assertThat(test().dsl().convert().from("an object").to(Object.class)).isEqualTo("an object");
-        });
-
-        it("accepts a supplier as a converter",()->{
-          test().configure().useConverter(() -> "a value");
-          assertThat(test().dsl().convert().from(Nothing.INSTANCE).to(Object.class)).isEqualTo("a value");
-        });
-        it("accepts a consumer as a converter",()->{
-          AtomicReference<String> converterArgument = new AtomicReference<>();
-          test().configure().useConverter(converterArgument::set);
-          assertThat(test().dsl().convert().from("an object").to(Nothing.class)).isNull();
-          assertThat(converterArgument.get()).isEqualTo("an object");
-        });
-
-        it("accepts a function reference as converter", () -> {
-          test().configure().useConverter(new FunctionRef<Object, Object>((in) -> in) {});
-          assertThat(test().dsl().convert().from("an object").to(Object.class)).isEqualTo("an object");
-        });
-
-        it("accepts a bifunction reference that takes the dsl as second arg as a converter",()->{
-          test().configure().useConverter(new BiFunctionRef<Object, Bean2beanTask, Object>((input, b2b)-> input) {});
-          assertThat(test().dsl().convert().from("an object").to(Object.class)).isEqualTo("an object");
-        });
-
-        it("accepts a supplier reference as a converter",()->{
-          test().configure().useConverter(new SupplierRef<Object>(() -> "a value") {});
-          assertThat(test().dsl().convert().from(Nothing.INSTANCE).to(Object.class)).isEqualTo("a value");
-        });
-
-        it("accepts a consumer reference as a converter",()->{
-          AtomicReference<String> converterArgument = new AtomicReference<>();
-          test().configure().useConverter(new ConsumerRef<String>(converterArgument::set){});
-          assertThat(test().dsl().convert().from("an object").to(Nothing.class)).isNull();
-          assertThat(converterArgument.get()).isEqualTo("an object");
-        });
-
-      });
-
-      describe("used to register explicitly scoped converters", () -> {
-        describe("using type instances to limit scope", () -> {
           it("accepts a function as converter", () -> {
-            test().configure().scopingTo().accept(Object.class).andProduce(Object.class).useConverter((in) -> in);
+            test().configure().useConverter((in) -> in);
             assertThat(test().dsl().convert().from("an object").to(Object.class)).isEqualTo("an object");
           });
 
           it("accepts a bifunction that takes the dsl as second arg as a converter",()->{
-            test().configure().scopingTo().accept(Object.class).andProduce(Object.class).useConverter((input, b2b)-> input);
+            test().configure().useConverter((input, b2b)-> input);
             assertThat(test().dsl().convert().from("an object").to(Object.class)).isEqualTo("an object");
           });
 
           it("accepts a supplier as a converter",()->{
-            test().configure().scopingTo().accept(Object.class).andProduce(Object.class).useConverter(() -> "a value");
+            test().configure().useConverter(() -> "a value");
+            assertThat(test().dsl().convert().from(Nothing.INSTANCE).to(Object.class)).isEqualTo("a value");
+          });
+          it("accepts a consumer as a converter",()->{
+            AtomicReference<String> converterArgument = new AtomicReference<>();
+            test().configure().useConverter(converterArgument::set);
+            assertThat(test().dsl().convert().from("an object").to(Nothing.class)).isNull();
+            assertThat(converterArgument.get()).isEqualTo("an object");
+          });
+
+        });
+        describe("for lambda references", () -> {
+          it("accepts a function reference as converter", () -> {
+            test().configure().useConverter(new FunctionRef<Object, Object>((in) -> in) {});
+            assertThat(test().dsl().convert().from("an object").to(Object.class)).isEqualTo("an object");
+          });
+
+          it("accepts a bifunction reference that takes the dsl as second arg as a converter",()->{
+            test().configure().useConverter(new BiFunctionRef<Object, Bean2beanTask, Object>((input, b2b)-> input) {});
+            assertThat(test().dsl().convert().from("an object").to(Object.class)).isEqualTo("an object");
+          });
+
+          it("accepts a supplier reference as a converter",()->{
+            test().configure().useConverter(new SupplierRef<Object>(() -> "a value") {});
+            assertThat(test().dsl().convert().from(Nothing.INSTANCE).to(Object.class)).isEqualTo("a value");
+          });
+
+          it("accepts a consumer reference as a converter",()->{
+            AtomicReference<String> converterArgument = new AtomicReference<>();
+            test().configure().useConverter(new ConsumerRef<String>(converterArgument::set){});
+            assertThat(test().dsl().convert().from("an object").to(Nothing.class)).isNull();
+            assertThat(converterArgument.get()).isEqualTo("an object");
+          });
+        });
+      });
+
+      describe("scoping explicitly by type domains", () -> {
+        describe("from type instances", () -> {
+          describe("for lambda instances", () -> {
+            it("accepts a function as converter", () -> {
+              test().configure().scopingTo().accept(Object.class).andProduce(Object.class).useConverter((in) -> in);
+              assertThat(test().dsl().convert().from("an object").to(Object.class)).isEqualTo("an object");
+            });
+
+            it("accepts a bifunction that takes the dsl as second arg as a converter",()->{
+              test().configure().scopingTo().accept(Object.class).andProduce(Object.class).useConverter((input, b2b)-> input);
+              assertThat(test().dsl().convert().from("an object").to(Object.class)).isEqualTo("an object");
+            });
+
+            it("accepts a supplier as a converter",()->{
+              test().configure().scopingTo().accept(Object.class).andProduce(Object.class).useConverter(() -> "a value");
+              assertThat(test().dsl().convert().from(null).to(Object.class)).isEqualTo("a value");
+            });
+
+            it("accepts a consumer as a converter",()->{
+              AtomicReference<String> converterArgument = new AtomicReference<>();
+
+              test().configure().scopingTo().accept(Object.class).andProduce(Object.class)
+                .useConverter(converterArgument::set);
+
+              assertThat(test().dsl().convert().from("an object").to(Nothing.class)).isNull();
+              assertThat(converterArgument.get()).isEqualTo("an object");
+            });
+          });
+          describe("for lambda references", () -> {
+            it("accepts a function as converter", () -> {
+              test().configure().scopingTo().accept(Object.class).andProduce(Object.class)
+                .useConverter(new FunctionRef<Object, Object>((in) -> in) {});
+              assertThat(test().dsl().convert().from("an object").to(Object.class)).isEqualTo("an object");
+            });
+
+            it("accepts a bifunction that takes the dsl as second arg as a converter",()->{
+              test().configure().scopingTo().accept(Object.class).andProduce(Object.class)
+                .useConverter(new BiFunctionRef<Object, Bean2beanTask, Object>((input, b2b)-> input) {});
+              assertThat(test().dsl().convert().from("an object").to(Object.class)).isEqualTo("an object");
+            });
+
+            it("accepts a supplier as a converter",()->{
+              test().configure().scopingTo().accept(Object.class).andProduce(Object.class)
+                .useConverter(new SupplierRef<Object>(() -> "a value") {});
+              assertThat(test().dsl().convert().from(null).to(Object.class)).isEqualTo("a value");
+            });
+
+            it("accepts a consumer as a converter",()->{
+              AtomicReference<String> converterArgument = new AtomicReference<>();
+
+              test().configure().scopingTo().accept(Object.class).andProduce(Object.class)
+                .useConverter(new ConsumerRef<String>(converterArgument::set) {});
+
+              assertThat(test().dsl().convert().from("an object").to(Nothing.class)).isNull();
+              assertThat(converterArgument.get()).isEqualTo("an object");
+            });
+          });
+
+        });
+        describe("from type references", () -> {
+          describe("for lambda instances", () -> {
+            it("accepts a function as converter", () -> {
+              test().configure()
+                .scopingTo().accept(new TypeRef<Object>(){}).andProduce(new TypeRef<Object>(){})
+                .useConverter((in) -> in);
+              assertThat(test().dsl().convert().from("an object").to(Object.class)).isEqualTo("an object");
+            });
+
+            it("accepts a bifunction that takes the dsl as second arg as a converter",()->{
+              test().configure()
+                .scopingTo().accept(new TypeRef<Object>(){}).andProduce(new TypeRef<Object>(){})
+                .useConverter((input, b2b)-> input);
+              assertThat(test().dsl().convert().from("an object").to(Object.class)).isEqualTo("an object");
+            });
+
+            it("accepts a supplier as a converter",()->{
+              test().configure()
+                .scopingTo().accept(new TypeRef<Object>(){}).andProduce(new TypeRef<Object>(){})
+                .useConverter(() -> "a value");
+              assertThat(test().dsl().convert().from(null).to(Object.class)).isEqualTo("a value");
+            });
+
+            it("accepts a consumer as a converter",()->{
+              AtomicReference<String> converterArgument = new AtomicReference<>();
+
+              test().configure()
+                .scopingTo().accept(new TypeRef<Object>(){}).andProduce(new TypeRef<Object>(){})
+                .useConverter(converterArgument::set);
+
+              assertThat(test().dsl().convert().from("an object").to(Nothing.class)).isNull();
+              assertThat(converterArgument.get()).isEqualTo("an object");
+            });
+          });
+          describe("for lambda references", () -> {
+            it("accepts a function as converter", () -> {
+              test().configure()
+                .scopingTo().accept(new TypeRef<Object>(){}).andProduce(new TypeRef<Object>(){})
+                .useConverter(new FunctionRef<Object, Object>((in) -> in) {});
+              assertThat(test().dsl().convert().from("an object").to(Object.class)).isEqualTo("an object");
+            });
+
+            it("accepts a bifunction that takes the dsl as second arg as a converter",()->{
+              test().configure()
+                .scopingTo().accept(new TypeRef<Object>(){}).andProduce(new TypeRef<Object>(){})
+                .useConverter(new BiFunctionRef<Object, Bean2beanTask, Object>((input, b2b)-> input) {});
+              assertThat(test().dsl().convert().from("an object").to(Object.class)).isEqualTo("an object");
+            });
+
+            it("accepts a supplier as a converter",()->{
+              test().configure()
+                .scopingTo().accept(new TypeRef<Object>(){}).andProduce(new TypeRef<Object>(){})
+                .useConverter(new SupplierRef<Object>(() -> "a value") {});
+              assertThat(test().dsl().convert().from(null).to(Object.class)).isEqualTo("a value");
+            });
+
+            it("accepts a consumer as a converter",()->{
+              AtomicReference<String> converterArgument = new AtomicReference<>();
+
+              test().configure()
+                .scopingTo().accept(new TypeRef<Object>(){}).andProduce(new TypeRef<Object>(){})
+                .useConverter(new ConsumerRef<String>(converterArgument::set) {});
+
+              assertThat(test().dsl().convert().from("an object").to(Nothing.class)).isNull();
+              assertThat(converterArgument.get()).isEqualTo("an object");
+            });
+          });
+
+
+        });
+      });
+
+      describe("scoping explicity using a predicate", () -> {
+        describe("for lambda instances", () -> {
+          it("accepts a function as converter", () -> {
+            test().configure().scopingWith(this::acceptAnyInput).useConverter((in) -> in);
+            assertThat(test().dsl().convert().from("an object").to(Object.class)).isEqualTo("an object");
+          });
+
+          it("accepts a bifunction that takes the dsl as second arg as a converter", () -> {
+            test().configure().scopingWith(this::acceptAnyInput).useConverter((input, b2b)-> input);
+            assertThat(test().dsl().convert().from("an object").to(Object.class)).isEqualTo("an object");
+          });
+
+          it("accepts a supplier as a converter",()->{
+            test().configure().scopingWith(this::acceptAnyInput).useConverter(() -> "a value");
             assertThat(test().dsl().convert().from(null).to(Object.class)).isEqualTo("a value");
           });
 
           it("accepts a consumer as a converter",()->{
             AtomicReference<String> converterArgument = new AtomicReference<>();
-
-            test().configure().scopingTo().accept(Object.class).andProduce(Object.class)
-              .useConverter(converterArgument::set);
-
+            test().configure().scopingWith(this::acceptAnyInput).useConverter(converterArgument::set);
             assertThat(test().dsl().convert().from("an object").to(Nothing.class)).isNull();
             assertThat(converterArgument.get()).isEqualTo("an object");
           });
         });
-        describe("using type references to limit scope", () -> {
+        describe("for lambda references", () -> {
           it("accepts a function as converter", () -> {
-            test().configure()
-              .scopingTo().accept(new TypeRef<Object>(){}).andProduce(new TypeRef<Object>(){})
-              .useConverter((in) -> in);
+            test().configure().scopingWith(this::acceptAnyInput)
+              .useConverter(new FunctionRef<Object, Object>((in) -> in) {});
             assertThat(test().dsl().convert().from("an object").to(Object.class)).isEqualTo("an object");
           });
 
-          it("accepts a bifunction that takes the dsl as second arg as a converter",()->{
-            test().configure()
-              .scopingTo().accept(new TypeRef<Object>(){}).andProduce(new TypeRef<Object>(){})
-              .useConverter((input, b2b)-> input);
+          it("accepts a bifunction that takes the dsl as second arg as a converter", () -> {
+            test().configure().scopingWith(this::acceptAnyInput)
+              .useConverter(new BiFunctionRef<Object, Bean2beanTask, Object>((input, b2b)-> input) {});
             assertThat(test().dsl().convert().from("an object").to(Object.class)).isEqualTo("an object");
           });
 
           it("accepts a supplier as a converter",()->{
-            test().configure()
-              .scopingTo().accept(new TypeRef<Object>(){}).andProduce(new TypeRef<Object>(){})
-              .useConverter(() -> "a value");
+            test().configure().scopingWith(this::acceptAnyInput)
+              .useConverter(new SupplierRef<Object>(() -> "a value") {});
             assertThat(test().dsl().convert().from(null).to(Object.class)).isEqualTo("a value");
           });
 
           it("accepts a consumer as a converter",()->{
             AtomicReference<String> converterArgument = new AtomicReference<>();
-
-            test().configure()
-              .scopingTo().accept(new TypeRef<Object>(){}).andProduce(new TypeRef<Object>(){})
-              .useConverter(converterArgument::set);
-
+            test().configure().scopingWith(this::acceptAnyInput)
+              .useConverter(new ConsumerRef<String>(converterArgument::set) {});
             assertThat(test().dsl().convert().from("an object").to(Nothing.class)).isNull();
             assertThat(converterArgument.get()).isEqualTo("an object");
           });
         });
-
-      });
-
-      describe("used to register predicate scoped converters", () -> {
-
-        it("accepts a function as converter", () -> {
-          test().configure().scopingWith(this::acceptAnyInput).useConverter((in) -> in);
-          assertThat(test().dsl().convert().from("an object").to(Object.class)).isEqualTo("an object");
-        });
-
-        it("accepts a bifunction that takes the dsl as second arg as a converter", () -> {
-          test().configure().scopingWith(this::acceptAnyInput).useConverter((input, b2b)-> input);
-          assertThat(test().dsl().convert().from("an object").to(Object.class)).isEqualTo("an object");
-        });
-
-        it("accepts a supplier as a converter",()->{
-          test().configure().scopingWith(this::acceptAnyInput).useConverter(() -> "a value");
-          assertThat(test().dsl().convert().from(null).to(Object.class)).isEqualTo("a value");
-        });
-
-        it("accepts a consumer as a converter",()->{
-          AtomicReference<String> converterArgument = new AtomicReference<>();
-          test().configure().scopingWith(this::acceptAnyInput).useConverter(converterArgument::set);
-          assertThat(test().dsl().convert().from("an object").to(Nothing.class)).isNull();
-          assertThat(converterArgument.get()).isEqualTo("an object");
-        });
-
       });
     });
   }


### PR DESCRIPTION
Addresses https://github.com/kfgodel/bean2bean/issues/67
Improves registration dsl by accepting lambda references 